### PR TITLE
Avoid exceptions on `UUID` constructors

### DIFF
--- a/memeid/src/main/java/memeid/Node.java
+++ b/memeid/src/main/java/memeid/Node.java
@@ -29,6 +29,20 @@ import static memeid.Bits.fromBytes;
 
 public class Node {
 
+    private static Node instance;
+
+    public static Node getInstance() {
+        if (instance == null) {
+            try {
+                instance = new Node();
+            } catch (SocketException | UnknownHostException | NoSuchAlgorithmException e) {
+                throw new RuntimeException("Unable to instantiate Node", e);
+            }
+        }
+
+        return instance;
+    }
+
     /**
      * @see <a href="https://tools.ietf.org/html/rfc4122#section-4.1.5">RFC-4122</a>
      */

--- a/memeid/src/main/java/memeid/UUID.java
+++ b/memeid/src/main/java/memeid/UUID.java
@@ -16,8 +16,6 @@
 
 package memeid;
 
-import java.net.SocketException;
-import java.net.UnknownHostException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -410,8 +408,6 @@ public class UUID implements Comparable<UUID> {
             return Bits.readByte(Mask.CLOCK_SEQ_HIGH, Offset.CLOCK_SEQ_HIGH, this.asJava().clockSequence());
         }
 
-        private static Node defaultNode = null;
-
         public V1(java.util.UUID uuid) {
             super(uuid);
         }
@@ -422,12 +418,8 @@ public class UUID implements Comparable<UUID> {
          *
          * @return a {@link V1} UUID
          */
-        public static V1 next() throws NoSuchAlgorithmException, SocketException, UnknownHostException {
-            if (defaultNode == null) {
-                defaultNode = new Node();
-            }
-
-            return next(defaultNode);
+        public static V1 next() {
+            return next(Node.getInstance());
         }
 
         /**

--- a/memeid/src/main/java/memeid/UUID.java
+++ b/memeid/src/main/java/memeid/UUID.java
@@ -494,14 +494,23 @@ public class UUID implements Comparable<UUID> {
          * @param namespace   {@link UUID} used for the {@link V3} generation
          * @param name        name used for the {@link V3} generation
          * @param nameToBytes function used to convert the name to a byte array
+         * @param <A>         the type of the name parameter
          * @return a {@link V3} UUID
          */
-        public static <A> UUID from(UUID namespace, A name, Function<A, byte[]> nameToBytes) throws NoSuchAlgorithmException {
-            MessageDigest messageDigest = MessageDigest.getInstance("MD5");
-            messageDigest.update(toBytes(namespace.getMostSignificantBits()));
-            messageDigest.update(toBytes(namespace.getLeastSignificantBits()));
-            messageDigest.update(nameToBytes.apply(name));
-            byte[] bytes = messageDigest.digest();
+        public static <A> UUID from(UUID namespace, A name, Function<A, byte[]> nameToBytes) {
+            MessageDigest md;
+
+            try {
+                md = MessageDigest.getInstance("MD5");
+            } catch (NoSuchAlgorithmException nsae) {
+                throw new InternalError("MD5 not supported", nsae);
+            }
+
+            md.update(toBytes(namespace.getMostSignificantBits()));
+            md.update(toBytes(namespace.getLeastSignificantBits()));
+            md.update(nameToBytes.apply(name));
+
+            byte[] bytes = md.digest();
 
             long rawMsb = fromBytes(Arrays.copyOfRange(bytes, 0, 8));
             long rawLsb = fromBytes(Arrays.copyOfRange(bytes, 8, 16));
@@ -592,14 +601,22 @@ public class UUID implements Comparable<UUID> {
          * @param namespace   {@link UUID} used for the {@link V5} generation
          * @param name        name used for the {@link V5} generation
          * @param nameToBytes function used to convert the name to a byte array
+         * @param <A>         the type of the name parameter
          * @return a {@link V5} UUID
          */
-        public static <A> UUID from(UUID namespace, A name, Function<A, byte[]> nameToBytes) throws NoSuchAlgorithmException {
-            MessageDigest messageDigest = MessageDigest.getInstance("SHA1");
-            messageDigest.update(toBytes(namespace.getMostSignificantBits()));
-            messageDigest.update(toBytes(namespace.getLeastSignificantBits()));
-            messageDigest.update(nameToBytes.apply(name));
-            byte[] bytes = messageDigest.digest();
+        public static <A> UUID from(UUID namespace, A name, Function<A, byte[]> nameToBytes) {
+            MessageDigest md;
+
+            try {
+                md = MessageDigest.getInstance("SHA1");
+            } catch (NoSuchAlgorithmException nsae) {
+                throw new InternalError("SHA1 not supported", nsae);
+            }
+
+            md.update(toBytes(namespace.getMostSignificantBits()));
+            md.update(toBytes(namespace.getLeastSignificantBits()));
+            md.update(nameToBytes.apply(name));
+            byte[] bytes = md.digest();
 
             long rawMsb = fromBytes(Arrays.copyOfRange(bytes, 0, 8));
             long rawLsb = fromBytes(Arrays.copyOfRange(bytes, 8, 16));


### PR DESCRIPTION
# What has been done in this PR?

Avoid `NoSuchAlgorithmException` in `UUID` constructors that shouldn't happen in a normal JVM by throwing an `InternalError` runtime exception.