### PR TITLE
Remove `UUID` deps from circe and add `memeid4s-scalacheck` project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val `memeid4s-doobie` = project
   .settings(dependencies.common, dependencies.doobie)
 
 lazy val `memeid4s-circe` = project
-  .dependsOn(`memeid4s-cats`)
+  .dependsOn(`memeid4s-cats` % "compile->compile;test->test")
   .settings(dependencies.common, dependencies.circe)
 
 lazy val `memeid4s-http4s` = project

--- a/build.sbt
+++ b/build.sbt
@@ -26,16 +26,18 @@ lazy val `memeid` = project
   .settings(dependencies.common)
 
 lazy val memeid4s = project
-  .dependsOn(`memeid` % "compile->compile;test->test")
+  .dependsOn(`memeid`)
+  .dependsOn(`memeid4s-scalacheck` % "test->test")
   .settings(dependencies.common)
 
 lazy val `memeid4s-cats` = project
-  .dependsOn(memeid4s % "compile->compile;test->test")
+  .dependsOn(`memeid4s`)
+  .dependsOn(`memeid4s-scalacheck` % "test->test")
   .settings(dependencies.common, dependencies.cats)
   .settings(dependencies.compilerPlugins)
 
 lazy val `memeid4s-literal` = project
-  .dependsOn(memeid)
+  .dependsOn(`memeid4s`)
   .settings(dependencies.common, dependencies.literal)
 
 lazy val `memeid4s-doobie` = project
@@ -43,12 +45,18 @@ lazy val `memeid4s-doobie` = project
   .settings(dependencies.common, dependencies.doobie)
 
 lazy val `memeid4s-circe` = project
-  .dependsOn(`memeid4s-cats` % "compile->compile;test->test")
+  .dependsOn(`memeid4s-cats`)
+  .dependsOn(`memeid4s-scalacheck` % "test->test")
   .settings(dependencies.common, dependencies.circe)
 
 lazy val `memeid4s-http4s` = project
-  .dependsOn(`memeid4s-cats` % "compile->compile;test->test")
+  .dependsOn(`memeid4s-cats`)
+  .dependsOn(`memeid4s-scalacheck` % "test->test")
   .settings(dependencies.common, dependencies.http4s)
+
+lazy val `memeid4s-scalacheck` = project
+  .dependsOn(memeid)
+  .settings(dependencies.scalacheck)
 
 lazy val allProjects: Seq[ProjectReference] = Seq(
   `memeid`,
@@ -57,5 +65,6 @@ lazy val allProjects: Seq[ProjectReference] = Seq(
   `memeid4s-literal`,
   `memeid4s-doobie`,
   `memeid4s-circe`,
-  `memeid4s-http4s`
+  `memeid4s-http4s`,
+  `memeid4s-scalacheck`
 )

--- a/docs/README.md
+++ b/docs/README.md
@@ -294,6 +294,27 @@ UUID.v3[IO, String](namespace, "my-secret-code")
 UUID.v5[IO, String](namespace, "my-secret-code")
 ```
 
+##### Scalacheck
+
+```scala
+libraryDependencies += "com.47deg" %% "memeid4s-scalacheck" % "@VERSION@"
+```
+
+The scalacheck integration provides `Arbitrary` instances for the `UUID`, as well as for the different version classes.
+
+```scala mdoc:silent
+import org.scalacheck.Arbitrary.arbitrary
+import memeid4s.scalacheck.arbitrary.instances._
+
+arbitrary[UUID]
+arbitrary[UUID.V1]
+arbitrary[UUID.V2]
+arbitrary[UUID.V3]
+arbitrary[UUID.V4]
+arbitrary[UUID.V5]
+```
+
+
 ## References
 
 - [RFC 4122 - A Universally Unique Identifier](https://www.ietf.org/rfc/rfc4122.txt)

--- a/memeid/src/main/java/memeid/Node.java
+++ b/memeid/src/main/java/memeid/Node.java
@@ -90,6 +90,11 @@ public class Node {
         id = fromBytes(bytes);
     }
 
+    public Node(short clockSequence, long id) {
+        this.clockSequence = clockSequence;
+        this.id = id;
+    }
+
     private static final List<String> DATA_SOURCES = Arrays.asList("java.vendor", "java.vendor.url", "java.version", "os.arch", "os.name", "os.version");
 
 }

--- a/memeid/src/main/java/memeid/UUID.java
+++ b/memeid/src/main/java/memeid/UUID.java
@@ -408,7 +408,7 @@ public class UUID implements Comparable<UUID> {
             return Bits.readByte(Mask.CLOCK_SEQ_HIGH, Offset.CLOCK_SEQ_HIGH, this.asJava().clockSequence());
         }
 
-        public V1(java.util.UUID uuid) {
+        private V1(java.util.UUID uuid) {
             super(uuid);
         }
 
@@ -474,7 +474,7 @@ public class UUID implements Comparable<UUID> {
      */
     public final static class V2 extends UUID {
 
-        public V2(java.util.UUID uuid) {
+        private V2(java.util.UUID uuid) {
             super(uuid);
         }
 
@@ -491,8 +491,8 @@ public class UUID implements Comparable<UUID> {
         /**
          * Construct a namespace name-based {@link V3} UUID. Uses MD5 as a hash algorithm
          *
-         * @param namespace   {@link UUID} used for the {@link V3} generation
-         * @param name        name used for the {@link V3} generation in string format
+         * @param namespace {@link UUID} used for the {@link V3} generation
+         * @param name      name used for the {@link V3} generation in string format
          * @return a {@link V3} UUID
          */
         public static UUID from(UUID namespace, String name) {
@@ -532,7 +532,7 @@ public class UUID implements Comparable<UUID> {
             return new V3(new java.util.UUID(msb, lsb));
         }
 
-        public V3(java.util.UUID uuid) {
+        private V3(java.util.UUID uuid) {
             super(uuid);
         }
 
@@ -552,8 +552,8 @@ public class UUID implements Comparable<UUID> {
          * @param msb Most significant bit in long representation
          * @param lsb Least significant bit in long representation
          */
-        public V4(long msb, long lsb) {
-            this(new java.util.UUID(
+        public static UUID from(long msb, long lsb) {
+            return new UUID.V4(new java.util.UUID(
                     writeByte(Mask.VERSION, Offset.VERSION, msb, 0x4),
                     writeByte(Mask.V4_LSB, Offset.V4_LSB, lsb, 0x2)));
         }
@@ -591,7 +591,7 @@ public class UUID implements Comparable<UUID> {
             return squuid(MILLISECONDS.toSeconds(System.currentTimeMillis()));
         }
 
-        public V4(java.util.UUID uuid) {
+        private V4(java.util.UUID uuid) {
             super(uuid);
         }
 
@@ -609,8 +609,8 @@ public class UUID implements Comparable<UUID> {
         /**
          * Construct a namespace name-based {@link V5} UUID. Uses SHA1 as a hash algorithm
          *
-         * @param namespace   {@link UUID} used for the {@link V5} generation
-         * @param name        name used for the {@link V5} generation in string format
+         * @param namespace {@link UUID} used for the {@link V5} generation
+         * @param name      name used for the {@link V5} generation in string format
          * @return a {@link V5} UUID
          */
         public static UUID from(UUID namespace, String name) {
@@ -649,7 +649,7 @@ public class UUID implements Comparable<UUID> {
             return new V5(new java.util.UUID(msb, lsb));
         }
 
-        public V5(java.util.UUID uuid) {
+        private V5(java.util.UUID uuid) {
             super(uuid);
         }
 

--- a/memeid/src/main/java/memeid/UUID.java
+++ b/memeid/src/main/java/memeid/UUID.java
@@ -418,7 +418,7 @@ public class UUID implements Comparable<UUID> {
          *
          * @return a {@link V1} UUID
          */
-        public static V1 next() {
+        public static UUID next() {
             return next(Node.getInstance());
         }
 
@@ -429,7 +429,7 @@ public class UUID implements Comparable<UUID> {
          * @param node Node for the V1 UUID generation
          * @return a {@link V1} UUID
          */
-        public static V1 next(Node node) {
+        public static UUID next(Node node) {
             return next(node, Timestamp::monotonic);
         }
 
@@ -441,7 +441,7 @@ public class UUID implements Comparable<UUID> {
          * @param monotonicSupplier monotonic timestamp which assures the V1 UUID time is unique
          * @return a {@link V1} UUID
          */
-        public static V1 next(Node node, LongSupplier monotonicSupplier) {
+        public static UUID next(Node node, LongSupplier monotonicSupplier) {
             final long timestamp = monotonicSupplier.getAsLong();
             final long low = readByte(Mask.TIME_LOW, Offset.TIME_LOW, timestamp);
             final long mid = readByte(Mask.TIME_MID, Offset.TIME_MID, timestamp);

--- a/memeid/src/test/scala/memeid/UUIDSpec.scala
+++ b/memeid/src/test/scala/memeid/UUIDSpec.scala
@@ -18,8 +18,8 @@ package memeid
 
 import java.util.Optional
 
-import memeid.arbitrary.instances._
-import org.scalacheck.Gen
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
@@ -59,51 +59,68 @@ class UUIDSpec extends Specification with ScalaCheck {
 
   "uuid.asV* methods" should {
 
-    "uuid.asV1 should return optional with uuid only if version is 1" in prop { uuid: UUID.V1 =>
-      (uuid.asV1 must be equalTo Optional.of[UUID.V1](uuid)) and
-        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
-        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
-        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+    "uuid.asV1 should return optional with uuid only if class is UUID.V1" in prop {
+      juuid: java.util.UUID =>
+        val uuid = new UUID.V1(juuid)
+
+        (uuid.asV1 must be equalTo Optional.of[UUID.V1](uuid)) and
+          (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+          (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+          (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+          (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
     }
 
-    "uuid.asV2 should return optional with uuid only if version is 2" in prop { uuid: UUID.V2 =>
-      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
-        (uuid.asV2 must be equalTo Optional.of[UUID.V2](uuid)) and
-        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
-        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+    "uuid.asV2 should return optional with uuid only if class is UUID.V2" in prop {
+      juuid: java.util.UUID =>
+        val uuid = new UUID.V2(juuid)
+
+        (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+          (uuid.asV2 must be equalTo Optional.of[UUID.V2](uuid)) and
+          (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+          (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+          (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
     }
 
-    "uuid.asV3 should return optional with uuid only if version is 3" in prop { uuid: UUID.V3 =>
-      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
-        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
-        (uuid.asV3 must be equalTo Optional.of[UUID.V3](uuid)) and
-        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+    "uuid.asV3 should return optional with uuid only if class is UUID.V3" in prop {
+      juuid: java.util.UUID =>
+        val uuid = new UUID.V3(juuid)
+
+        (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+          (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+          (uuid.asV3 must be equalTo Optional.of[UUID.V3](uuid)) and
+          (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+          (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
     }
 
-    "uuid.asV4 should return optional with uuid only if version is 4" in prop { uuid: UUID.V4 =>
-      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
-        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
-        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
-        (uuid.asV4 must be equalTo Optional.of[UUID.V4](uuid)) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+    "uuid.asV4 should return optional with uuid only if class is UUID.V4" in prop {
+      juuid: java.util.UUID =>
+        val uuid = new UUID.V4(juuid)
+
+        (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+          (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+          (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+          (uuid.asV4 must be equalTo Optional.of[UUID.V4](uuid)) and
+          (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
     }
 
-    "uuid.asV5 should return optional with uuid only if version is 5" in prop { uuid: UUID.V5 =>
-      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
-        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
-        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
-        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-        (uuid.asV5 must be equalTo Optional.of[UUID.V5](uuid))
+    "uuid.asV5 should return optional with uuid only if class is UUID.V5" in prop {
+      juuid: java.util.UUID =>
+        val uuid = new UUID.V5(juuid)
+
+        (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+          (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+          (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+          (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+          (uuid.asV5 must be equalTo Optional.of[UUID.V5](uuid))
     }
 
   }
 
   "uuid.isV* methods" should {
 
-    "uuid.isV1 should return true only if version is 1" in prop { uuid: UUID.V1 =>
+    "uuid.isV1 should return true only if class is UUID.V1" in prop { juuid: java.util.UUID =>
+      val uuid = new UUID.V1(juuid)
+
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beTrue) and
         (uuid.isV2 must beFalse) and
@@ -112,7 +129,9 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.isV5 must beFalse)
     }
 
-    "uuid.isV2 should return true only if version is 2" in prop { uuid: UUID.V2 =>
+    "uuid.isV2 should return true only if class is UUID.V2" in prop { juuid: java.util.UUID =>
+      val uuid = new UUID.V2(juuid)
+
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beFalse) and
         (uuid.isV2 must beTrue) and
@@ -121,7 +140,9 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.isV5 must beFalse)
     }
 
-    "uuid.isV3 should return true only if version is 3" in prop { uuid: UUID.V3 =>
+    "uuid.isV3 should return true only if class is UUID.V3" in prop { juuid: java.util.UUID =>
+      val uuid = new UUID.V3(juuid)
+
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beFalse) and
         (uuid.isV2 must beFalse) and
@@ -130,7 +151,9 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.isV5 must beFalse)
     }
 
-    "uuid.isV4 should return true only if version is 4" in prop { uuid: UUID.V4 =>
+    "uuid.isV4 should return true only if class is UUID.V4" in prop { juuid: java.util.UUID =>
+      val uuid = new UUID.V4(juuid)
+
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beFalse) and
         (uuid.isV2 must beFalse) and
@@ -139,7 +162,9 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.isV5 must beFalse)
     }
 
-    "uuid.isV5 should return true only if version is 5" in prop { uuid: UUID.V5 =>
+    "uuid.isV5 should return true only if class is UUID.V5" in prop { juuid: java.util.UUID =>
+      val uuid = new UUID.V5(juuid)
+
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beFalse) and
         (uuid.isV2 must beFalse) and
@@ -186,6 +211,13 @@ class UUIDSpec extends Specification with ScalaCheck {
         (UUID.NIL.getLeastSignificantBits must be equalTo 0L)
     }
 
+  }
+
+  implicit val UUIDArbitraryInstance: Arbitrary[UUID] = Arbitrary {
+    for {
+      msb <- arbitrary[Long]
+      lsb <- arbitrary[Long]
+    } yield UUID.from(msb, lsb)
   }
 
 }

--- a/memeid/src/test/scala/memeid/UUIDSpec.scala
+++ b/memeid/src/test/scala/memeid/UUIDSpec.scala
@@ -23,7 +23,7 @@ import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 
-@SuppressWarnings(Array("scalafix:Disable.toString"))
+@SuppressWarnings(Array("scalafix:Disable.toString", "scalafix:DisableSyntax.asInstanceOf"))
 class UUIDSpec extends Specification with ScalaCheck {
 
   "UUID.fromString" should {
@@ -59,67 +59,60 @@ class UUIDSpec extends Specification with ScalaCheck {
 
   "uuid.asV* methods" should {
 
-    "uuid.asV1 should return optional with uuid only if class is UUID.V1" in prop {
-      juuid: java.util.UUID =>
-        val uuid = new UUID.V1(juuid)
+    "uuid.asV1 should return optional with uuid only if class is UUID.V1" >> {
+      val uuid = UUID.V1.next.asInstanceOf[UUID.V1]
 
-        (uuid.asV1 must be equalTo Optional.of[UUID.V1](uuid)) and
-          (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
-          (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
-          (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-          (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+      (uuid.asV1 must be equalTo Optional.of[UUID.V1](uuid)) and
+        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
     }
 
-    "uuid.asV2 should return optional with uuid only if class is UUID.V2" in prop {
-      juuid: java.util.UUID =>
-        val uuid = new UUID.V2(juuid)
-
-        (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
-          (uuid.asV2 must be equalTo Optional.of[UUID.V2](uuid)) and
-          (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
-          (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-          (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+    "uuid.asV2 should return optional with uuid only if class is UUID.V2" in prop { uuid: UUID.V2 =>
+      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+        (uuid.asV2 must be equalTo Optional.of[UUID.V2](uuid)) and
+        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
     }
 
-    "uuid.asV3 should return optional with uuid only if class is UUID.V3" in prop {
-      juuid: java.util.UUID =>
-        val uuid = new UUID.V3(juuid)
+    "uuid.asV3 should return optional with uuid only if class is UUID.V3" >> {
+      val uuid = UUID.V3.from(UUID.V4.random, "miau").asInstanceOf[UUID.V3]
 
-        (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
-          (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
-          (uuid.asV3 must be equalTo Optional.of[UUID.V3](uuid)) and
-          (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-          (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+        (uuid.asV3 must be equalTo Optional.of[UUID.V3](uuid)) and
+        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
     }
 
-    "uuid.asV4 should return optional with uuid only if class is UUID.V4" in prop {
-      juuid: java.util.UUID =>
-        val uuid = new UUID.V4(juuid)
+    "uuid.asV4 should return optional with uuid only if class is UUID.V4" >> {
+      val uuid = UUID.V4.random.asInstanceOf[UUID.V4]
 
-        (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
-          (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
-          (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
-          (uuid.asV4 must be equalTo Optional.of[UUID.V4](uuid)) and
-          (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+        (uuid.asV4 must be equalTo Optional.of[UUID.V4](uuid)) and
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
     }
 
-    "uuid.asV5 should return optional with uuid only if class is UUID.V5" in prop {
-      juuid: java.util.UUID =>
-        val uuid = new UUID.V5(juuid)
+    "uuid.asV5 should return optional with uuid only if class is UUID.V5" >> {
+      val uuid = UUID.V5.from(UUID.V4.random, "miau").asInstanceOf[UUID.V5]
 
-        (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
-          (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
-          (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
-          (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-          (uuid.asV5 must be equalTo Optional.of[UUID.V5](uuid))
+      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+        (uuid.asV5 must be equalTo Optional.of[UUID.V5](uuid))
     }
 
   }
 
   "uuid.isV* methods" should {
 
-    "uuid.isV1 should return true only if class is UUID.V1" in prop { juuid: java.util.UUID =>
-      val uuid = new UUID.V1(juuid)
+    "uuid.isV1 should return true only if class is UUID.V1" >> {
+      val uuid = UUID.V1.next
 
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beTrue) and
@@ -129,9 +122,7 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.isV5 must beFalse)
     }
 
-    "uuid.isV2 should return true only if class is UUID.V2" in prop { juuid: java.util.UUID =>
-      val uuid = new UUID.V2(juuid)
-
+    "uuid.isV2 should return true only if class is UUID.V2" in prop { uuid: UUID.V2 =>
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beFalse) and
         (uuid.isV2 must beTrue) and
@@ -140,8 +131,8 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.isV5 must beFalse)
     }
 
-    "uuid.isV3 should return true only if class is UUID.V3" in prop { juuid: java.util.UUID =>
-      val uuid = new UUID.V3(juuid)
+    "uuid.isV3 should return true only if class is UUID.V3" >> {
+      val uuid = UUID.V3.from(UUID.V4.random, "miau")
 
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beFalse) and
@@ -151,8 +142,8 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.isV5 must beFalse)
     }
 
-    "uuid.isV4 should return true only if class is UUID.V4" in prop { juuid: java.util.UUID =>
-      val uuid = new UUID.V4(juuid)
+    "uuid.isV4 should return true only if class is UUID.V4" >> {
+      val uuid = UUID.V4.random
 
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beFalse) and
@@ -162,8 +153,8 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.isV5 must beFalse)
     }
 
-    "uuid.isV5 should return true only if class is UUID.V5" in prop { juuid: java.util.UUID =>
-      val uuid = new UUID.V5(juuid)
+    "uuid.isV5 should return true only if class is UUID.V5" >> {
+      val uuid = UUID.V5.from(UUID.V4.random, "miau")
 
       (uuid.isNil must beFalse) and
         (uuid.isV1 must beFalse) and
@@ -218,6 +209,11 @@ class UUIDSpec extends Specification with ScalaCheck {
       msb <- arbitrary[Long]
       lsb <- arbitrary[Long]
     } yield UUID.from(msb, lsb)
+  }
+
+  @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
+  implicit val UUIDV2ArbitraryInstance: Arbitrary[UUID.V2] = Arbitrary {
+    arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V2]).map(_.asInstanceOf[UUID.V2])
   }
 
 }

--- a/memeid/src/test/scala/memeid/V4Spec.scala
+++ b/memeid/src/test/scala/memeid/V4Spec.scala
@@ -36,12 +36,12 @@ class V4Spec extends Specification {
     }
 
     "be unable to create non-v4 values regardless of msb/lsb values provided" in {
-      val nonNull: UUID = new UUID.V4(0, 0)
+      val nonNull: UUID = UUID.V4.from(0, 0)
       nonNull must not be equalTo(UUID.NIL)
     }
 
     "generate version 4 UUIDs regardless of msb/lsb values provided" in {
-      val nonNull: UUID = new UUID.V4(0, 0)
+      val nonNull: UUID = UUID.V4.from(0, 0)
       nonNull.version must be equalTo 4
     }
 

--- a/memeid4s-cats/src/test/scala/memeid4s/cats/InstancesSpec.scala
+++ b/memeid4s-cats/src/test/scala/memeid4s/cats/InstancesSpec.scala
@@ -23,10 +23,10 @@ import cats.kernel.{Hash, Order}
 import cats.syntax.contravariant._
 import cats.syntax.show._
 
-import memeid.arbitrary.instances._
 import memeid4s.UUID
 import memeid4s.cats.instances._
 import memeid4s.digest.Digestible
+import memeid4s.scalacheck.arbitrary.instances._
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 

--- a/memeid4s-cats/src/test/scala/memeid4s/cats/UUIDLaws.scala
+++ b/memeid4s-cats/src/test/scala/memeid4s/cats/UUIDLaws.scala
@@ -19,13 +19,19 @@ package memeid4s.cats
 import cats.instances.option._
 import cats.kernel.laws.discipline.{HashTests, LowerBoundedTests, OrderTests, UpperBoundedTests}
 
-import memeid.arbitrary.instances._
 import memeid4s.UUID
 import memeid4s.cats.instances._
+import memeid4s.scalacheck.arbitrary.instances._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
 import org.specs2.mutable.Specification
 import org.typelevel.discipline.specs2.mutable.Discipline
 
 class UUIDLaws extends Specification with Discipline {
+
+  implicit private val UUID2UUIDArbitraryInstance: Arbitrary[UUID => UUID] = Arbitrary(
+    arbitrary[UUID].map(uuid => { _: UUID => uuid })
+  )
 
   checkAll("UUID", HashTests[UUID].hash)
   checkAll("UUID", OrderTests[UUID].order)

--- a/memeid4s-circe/src/main/scala/memeid4s/circe/instances.scala
+++ b/memeid4s-circe/src/main/scala/memeid4s/circe/instances.scala
@@ -16,18 +16,17 @@
 
 package memeid4s.circe
 
-import java.util.{UUID => JUUID}
-
 import io.circe.{Decoder, Encoder}
 import memeid4s.UUID
 
+@SuppressWarnings(Array("scalafix:DisableSyntax.valInAbstract"))
 trait instances {
 
-  implicit def UUIDEncoderInstance(implicit E: Encoder[JUUID]): Encoder[UUID] =
-    E.contramap(_.asJava)
+  implicit lazy val UUIDEncoderInstance: Encoder[UUID] =
+    Encoder.encodeUUID.contramap(_.asJava)
 
-  implicit def UUIDDecoderInstance(implicit D: Decoder[JUUID]): Decoder[UUID] =
-    D.map(UUID.fromUUID)
+  implicit lazy val UUIDDecoderInstance: Decoder[UUID] =
+    Decoder.decodeUUID.map(UUID.fromUUID)
 
 }
 

--- a/memeid4s-circe/src/test/scala/memeid4s/circe/CirceInstancesSpec.scala
+++ b/memeid4s-circe/src/test/scala/memeid4s/circe/CirceInstancesSpec.scala
@@ -38,7 +38,7 @@ class CirceInstancesSpec extends Specification with ScalaCheck {
 
   "Decoder[UUID]" should {
 
-    "encode UUID as JSON" in prop { uuid: UUID =>
+    "decode JSON as UUID" in prop { uuid: UUID =>
       val json = Json.fromString(uuid.show)
       Decoder[UUID].decodeJson(json) must beRight(uuid)
     }

--- a/memeid4s-circe/src/test/scala/memeid4s/circe/CirceInstancesSpec.scala
+++ b/memeid4s-circe/src/test/scala/memeid4s/circe/CirceInstancesSpec.scala
@@ -19,10 +19,10 @@ package memeid4s.circe
 import cats.syntax.show._
 
 import io.circe.{Decoder, Encoder, Json}
-import memeid.arbitrary.instances._
 import memeid4s.UUID
 import memeid4s.cats.instances._
 import memeid4s.circe.instances._
+import memeid4s.scalacheck.arbitrary.instances._
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification
 

--- a/memeid4s-circe/src/test/scala/memeid4s/circe/CirceInstancesSpec.scala
+++ b/memeid4s-circe/src/test/scala/memeid4s/circe/CirceInstancesSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019-2020 47 Degrees Open Source <http://47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memeid4s.circe
+
+import cats.syntax.show._
+
+import io.circe.{Decoder, Encoder, Json}
+import memeid.arbitrary.instances._
+import memeid4s.UUID
+import memeid4s.cats.instances._
+import memeid4s.circe.instances._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+class CirceInstancesSpec extends Specification with ScalaCheck {
+
+  "Encoder[UUID]" should {
+
+    "encode UUID as JSON" in prop { uuid: UUID =>
+      Encoder[UUID].apply(uuid) must be equalTo Json.fromString(uuid.show)
+    }
+
+  }
+
+  "Decoder[UUID]" should {
+
+    "encode UUID as JSON" in prop { uuid: UUID =>
+      val json = Json.fromString(uuid.show)
+      Decoder[UUID].decodeJson(json) must beRight(uuid)
+    }
+
+  }
+
+}

--- a/memeid4s-circe/src/test/scala/memeid4s/circe/UUIDCodecLaws.scala
+++ b/memeid4s-circe/src/test/scala/memeid4s/circe/UUIDCodecLaws.scala
@@ -18,10 +18,10 @@ package memeid4s.circe
 
 import io.circe.testing.CodecTests
 import io.circe.testing.instances._
-import memeid.arbitrary.instances._
 import memeid4s.UUID
 import memeid4s.cats.instances._
 import memeid4s.circe.instances._
+import memeid4s.scalacheck.arbitrary.instances._
 import org.specs2.mutable.Specification
 import org.typelevel.discipline.specs2.mutable.Discipline
 

--- a/memeid4s-circe/src/test/scala/memeid4s/circe/UUIDCodecLaws.scala
+++ b/memeid4s-circe/src/test/scala/memeid4s/circe/UUIDCodecLaws.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019-2020 47 Degrees Open Source <http://47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memeid4s.circe
+
+import io.circe.testing.CodecTests
+import io.circe.testing.instances._
+import memeid.arbitrary.instances._
+import memeid4s.UUID
+import memeid4s.cats.instances._
+import memeid4s.circe.instances._
+import org.specs2.mutable.Specification
+import org.typelevel.discipline.specs2.mutable.Discipline
+
+class UUIDCodecLaws extends Specification with Discipline {
+
+  checkAll("UUID", CodecTests[UUID].codec)
+  checkAll("UUID", CodecTests[UUID].unserializableCodec)
+
+}

--- a/memeid4s-http4s/src/test/scala/memeid4s/http4s/InstancesSpec.scala
+++ b/memeid4s-http4s/src/test/scala/memeid4s/http4s/InstancesSpec.scala
@@ -18,10 +18,10 @@ package memeid4s.http4s
 
 import cats.syntax.show._
 
-import memeid.arbitrary.instances._
 import memeid4s.UUID
 import memeid4s.cats.instances._
 import memeid4s.http4s.instances._
+import memeid4s.scalacheck.arbitrary.instances._
 import org.http4s.dsl.impl.QueryParamDecoderMatcher
 import org.http4s.{QueryParamEncoder, QueryParameterValue}
 import org.scalacheck.Gen

--- a/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
+++ b/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package memeid.arbitrary
+package memeid4s.scalacheck.arbitrary
 
 /*
  * Copyright 2019-2020 47 Degrees, LLC. <http://www.47deg.com>
@@ -37,10 +37,6 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 
 object instances {
-
-  implicit val UUID2UUIDArbitraryInstance: Arbitrary[UUID => UUID] = Arbitrary(
-    arbitrary[UUID].map(uuid => { _: UUID => uuid })
-  )
 
   implicit val UUIDArbitraryInstance: Arbitrary[UUID] = Arbitrary {
     for {

--- a/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
+++ b/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
@@ -32,7 +32,7 @@ package memeid4s.scalacheck.arbitrary
  * limitations under the License.
  */
 
-import memeid.UUID
+import memeid.{Node, UUID}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -45,9 +45,14 @@ object instances {
     } yield UUID.from(msb, lsb)
   }
 
-  @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
   implicit val UUIDV1ArbitraryInstance: Arbitrary[UUID.V1] = Arbitrary {
-    arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V1]).map(uuid => new UUID.V1(uuid.asJava))
+    for {
+      timestamp     <- arbitrary[Long]
+      clockSequence <- arbitrary[Short]
+      id            <- arbitrary[Long]
+      node = new Node(clockSequence, id)
+      uuid = UUID.V1.next(node, () => timestamp)
+    } yield new UUID.V1(uuid.asJava())
   }
 
   @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
@@ -55,19 +60,27 @@ object instances {
     arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V2]).map(uuid => new UUID.V2(uuid.asJava))
   }
 
-  @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
   implicit val UUIDV3ArbitraryInstance: Arbitrary[UUID.V3] = Arbitrary {
-    arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V3]).map(uuid => new UUID.V3(uuid.asJava))
+    for {
+      namespace <- arbitrary[UUID]
+      name      <- arbitrary[String]
+      uuid = UUID.V3.from(namespace, name)
+    } yield new UUID.V3(uuid.asJava())
   }
 
-  @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
   implicit val UUIDV4ArbitraryInstance: Arbitrary[UUID.V4] = Arbitrary {
-    arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V4]).map(uuid => new UUID.V4(uuid.asJava))
+    for {
+      msb <- arbitrary[Long]
+      lsb <- arbitrary[Long]
+    } yield new UUID.V4(msb, lsb)
   }
 
-  @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
   implicit val UUIDV5ArbitraryInstance: Arbitrary[UUID.V5] = Arbitrary {
-    arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V5]).map(uuid => new UUID.V5(uuid.asJava))
+    for {
+      namespace <- arbitrary[UUID]
+      name      <- arbitrary[String]
+      uuid = UUID.V5.from(namespace, name)
+    } yield new UUID.V5(uuid.asJava())
   }
 
 }

--- a/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
+++ b/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
@@ -36,6 +36,9 @@ import memeid.{Node, UUID}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 
+@SuppressWarnings(
+  Array("scalafix:DisableSyntax.isInstanceOf", "scalafix:DisableSyntax.asInstanceOf")
+)
 object instances {
 
   implicit val UUIDArbitraryInstance: Arbitrary[UUID] = Arbitrary {
@@ -51,36 +54,32 @@ object instances {
       clockSequence <- arbitrary[Short]
       id            <- arbitrary[Long]
       node = new Node(clockSequence, id)
-      uuid = UUID.V1.next(node, () => timestamp)
-    } yield new UUID.V1(uuid.asJava())
+    } yield UUID.V1.next(node, () => timestamp).asInstanceOf[UUID.V1]
   }
 
-  @SuppressWarnings(Array("scalafix:DisableSyntax.isInstanceOf"))
   implicit val UUIDV2ArbitraryInstance: Arbitrary[UUID.V2] = Arbitrary {
-    arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V2]).map(uuid => new UUID.V2(uuid.asJava))
+    arbitrary[UUID].retryUntil(_.isInstanceOf[UUID.V2]).map(_.asInstanceOf[UUID.V2])
   }
 
   implicit val UUIDV3ArbitraryInstance: Arbitrary[UUID.V3] = Arbitrary {
     for {
       namespace <- arbitrary[UUID]
       name      <- arbitrary[String]
-      uuid = UUID.V3.from(namespace, name)
-    } yield new UUID.V3(uuid.asJava())
+    } yield UUID.V3.from(namespace, name).asInstanceOf[UUID.V3]
   }
 
   implicit val UUIDV4ArbitraryInstance: Arbitrary[UUID.V4] = Arbitrary {
     for {
       msb <- arbitrary[Long]
       lsb <- arbitrary[Long]
-    } yield new UUID.V4(msb, lsb)
+    } yield UUID.V4.from(msb, lsb).asInstanceOf[UUID.V4]
   }
 
   implicit val UUIDV5ArbitraryInstance: Arbitrary[UUID.V5] = Arbitrary {
     for {
       namespace <- arbitrary[UUID]
       name      <- arbitrary[String]
-      uuid = UUID.V5.from(namespace, name)
-    } yield new UUID.V5(uuid.asJava())
+    } yield UUID.V5.from(namespace, name).asInstanceOf[UUID.V5]
   }
 
 }

--- a/memeid4s/src/main/scala/memeid4s/UUID.scala
+++ b/memeid4s/src/main/scala/memeid4s/UUID.scala
@@ -144,7 +144,7 @@ object UUID {
      * @param lsb Least significant bit in [[_root_.scala.Long Long]] representation
      * @return [[UUID.V4 V4]]
      */
-    @inline def apply(msb: Long, lsb: Long): UUID = new memeid.UUID.V4(msb, lsb)
+    @inline def apply(msb: Long, lsb: Long): UUID = memeid.UUID.V4.from(msb, lsb)
 
     // Construct a v4 (random) UUID.
     @inline def random: UUID = memeid.UUID.V4.random

--- a/memeid4s/src/test/scala/memeid4s/UUIDSpec.scala
+++ b/memeid4s/src/test/scala/memeid4s/UUIDSpec.scala
@@ -16,8 +16,8 @@
 
 package memeid4s
 
-import memeid.arbitrary.instances._
 import memeid4s.UUID.RichUUID
+import memeid4s.scalacheck.arbitrary.instances._
 import org.scalacheck.Gen
 import org.specs2.ScalaCheck
 import org.specs2.mutable.Specification

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -40,7 +40,9 @@ object dependencies {
   )
 
   val circe: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "io.circe" %% "circe-core" % V.circe
+    "io.circe"      %% "circe-core"        % V.circe,
+    "org.typelevel" %% "discipline-specs2" % V.`discipline-specs2` % Test,
+    "io.circe"      %% "circe-testing"     % V.circe % Test
   )
 
   val http4s: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -50,6 +50,10 @@ object dependencies {
     "org.http4s" %% "http4s-dsl"  % V.http4s % Test
   )
 
+  val scalacheck: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
+    "org.scalacheck" %% "scalacheck" % "1.14.3"
+  )
+
   val docs: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
     "org.tpolecat" %% "doobie-h2"  % V.doobie,
     "org.http4s"   %% "http4s-dsl" % V.http4s


### PR DESCRIPTION
# What has been done in this PR?

- Remove explicit dependencies as stated in #109 
- Add missing `memeid4s-circe` tests
- Move `Arbitrary` instances to its own module `memeid4s-scalacheck`
- Fix some return types in `memeid.UUID` class
- Make version constructors private

# Referenced issues

This PR closes #109 
This PR closes #106 