### PR TITLE
Cross publish to both Scala 2.12 and 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,23 +1,25 @@
-ThisBuild / scalaVersion := "2.13.1"
-ThisBuild / organization := "com.47deg"
+ThisBuild / scalaVersion       := "2.13.1"
+ThisBuild / crossScalaVersions := Seq("2.12.10", "2.13.1")
+ThisBuild / organization       := "com.47deg"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-addCommandAlias("ci-test", "fix --check; memeid-docs/mdoc; test")
-addCommandAlias("ci-docs", "memeid-docs/mdoc; headerCreateAll")
+addCommandAlias("ci-test", "fix --check; +docs/mdoc; +test")
+addCommandAlias("ci-docs", "+docs/mdoc; headerCreateAll")
 
-lazy val `memeid-root` = project
+lazy val `root` = project
   .in(file("."))
   .aggregate(allProjects: _*)
   .settings(skip in publish := true)
 
-lazy val `memeid-docs` = project
-  .dependsOn(allProjects.map(ClasspathDependency(_, None)): _*)
-  .enablePlugins(MdocPlugin)
+lazy val `docs` = project
+  .in(file("memeid-docs"))
   .settings(name := "memeid")
-  .settings(skip in publish := true)
+  .enablePlugins(MdocPlugin)
   .settings(mdocOut := file("."))
+  .settings(skip in publish := true)
   .settings(dependencies.docs)
+  .dependsOn(allProjects.map(ClasspathDependency(_, None)): _*)
 
 lazy val `memeid` = project
   .settings(crossPaths := false)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.12.10"
+ThisBuild / scalaVersion := "2.13.1"
 ThisBuild / organization := "com.47deg"
 
 Global / onChangedBuildSource := ReloadOnSourceChanges

--- a/build.sbt
+++ b/build.sbt
@@ -26,13 +26,11 @@ lazy val `memeid` = project
   .settings(dependencies.common)
 
 lazy val memeid4s = project
-  .dependsOn(`memeid`)
-  .dependsOn(`memeid4s-scalacheck` % "test->test")
+  .dependsOn(`memeid`, `memeid4s-scalacheck` % Test)
   .settings(dependencies.common)
 
 lazy val `memeid4s-cats` = project
-  .dependsOn(`memeid4s`)
-  .dependsOn(`memeid4s-scalacheck` % "test->test")
+  .dependsOn(`memeid4s`, `memeid4s-scalacheck` % Test)
   .settings(dependencies.common, dependencies.cats)
   .settings(dependencies.compilerPlugins)
 
@@ -41,17 +39,15 @@ lazy val `memeid4s-literal` = project
   .settings(dependencies.common, dependencies.literal)
 
 lazy val `memeid4s-doobie` = project
-  .dependsOn(`memeid4s-cats`)
+  .dependsOn(`memeid4s`)
   .settings(dependencies.common, dependencies.doobie)
 
 lazy val `memeid4s-circe` = project
-  .dependsOn(`memeid4s-cats`)
-  .dependsOn(`memeid4s-scalacheck` % "test->test")
+  .dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
   .settings(dependencies.common, dependencies.circe)
 
 lazy val `memeid4s-http4s` = project
-  .dependsOn(`memeid4s-cats`)
-  .dependsOn(`memeid4s-scalacheck` % "test->test")
+  .dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
   .settings(dependencies.common, dependencies.http4s)
 
 lazy val `memeid4s-scalacheck` = project

--- a/memeid/src/test/scala/memeid/SQUUIDSpec.scala
+++ b/memeid/src/test/scala/memeid/SQUUIDSpec.scala
@@ -16,6 +16,8 @@
 
 package memeid
 
+import scala.collection.parallel.immutable.ParRange
+
 import org.specs2.mutable.Specification
 
 @SuppressWarnings(Array("scalafix:Disable.scala.parallel"))
@@ -24,15 +26,15 @@ class SQUUIDSpec extends Specification {
   "SQUUID constructor" should {
 
     "create version 4 UUIDs" in {
-      val uuids = (1 to 10).par.map(_ => UUID.V4.squuid.version)
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V4.squuid.version).toVector.toSet
 
-      uuids.to[Set] must contain(exactly(4))
+      uuids must contain(exactly(4))
     }
 
     "not generate the same UUID twice" in {
-      val uuids = (1 to 10).par.map(_ => UUID.V4.squuid)
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V4.squuid).toVector.toSet
 
-      uuids.to[Set].size must be equalTo 10
+      uuids.size must be equalTo 10
     }
 
   }

--- a/memeid/src/test/scala/memeid/V1Spec.scala
+++ b/memeid/src/test/scala/memeid/V1Spec.scala
@@ -16,6 +16,8 @@
 
 package memeid
 
+import scala.collection.parallel.immutable.ParRange
+
 import org.specs2.mutable.Specification
 
 @SuppressWarnings(Array("scalafix:Disable.scala.parallel"))
@@ -24,9 +26,9 @@ class V1Spec extends Specification {
   "V1 constructor" should {
 
     "create version 1 UUIDs" in {
-      val ids = (1 to 10).par.map(_ => UUID.V1.next.version)
+      val ids = new ParRange(1 to 10).map(_ => UUID.V1.next.version).toVector.toSet
 
-      ids.to[Set] must contain(exactly(1))
+      ids must contain(exactly(1))
     }
 
     "create monotonically increasing UUIDs" in {
@@ -37,13 +39,13 @@ class V1Spec extends Specification {
     }
 
     "not generate the same UUID twice" in {
-      val ids = (1 to 10).par.map(_ => UUID.V1.next).toSet
+      val ids = new ParRange(1 to 10).map(_ => UUID.V1.next).toSet
 
       ids.size must be equalTo 10
     }
 
     "not generate the same UUID twice with high concurrency" in {
-      val ids = (1 to 999).par.map(_ => UUID.V1.next).toSet
+      val ids = new ParRange(1 to 999).map(_ => UUID.V1.next).toSet
 
       ids.size must be equalTo 999
     }

--- a/memeid/src/test/scala/memeid/V4Spec.scala
+++ b/memeid/src/test/scala/memeid/V4Spec.scala
@@ -16,6 +16,8 @@
 
 package memeid
 
+import scala.collection.parallel.immutable.ParRange
+
 import org.specs2.mutable.Specification
 
 @SuppressWarnings(Array("scalafix:Disable.scala.parallel"))
@@ -24,15 +26,15 @@ class V4Spec extends Specification {
   "V4 constructor" should {
 
     "create version 4 UUIDs" in {
-      val uuids = (1 to 10).par.map(_ => UUID.V4.random.version)
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V4.random.version).toVector.toSet
 
-      uuids.to[Set] must contain(exactly(4))
+      uuids must contain(exactly(4))
     }
 
     "not generate the same UUID twice" in {
-      val uuids = (1 to 10).par.map(_ => UUID.V4.random)
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V4.random).toVector.toSet
 
-      uuids.to[Set].size must be equalTo 10
+      uuids.size must be equalTo 10
     }
 
     "be unable to create non-v4 values regardless of msb/lsb values provided" in {

--- a/memeid4s-http4s/src/main/scala/memeid4s/http4s/instances.scala
+++ b/memeid4s-http4s/src/main/scala/memeid4s/http4s/instances.scala
@@ -17,13 +17,11 @@
 package memeid4s.http4s
 
 import cats.syntax.either._
-import cats.syntax.show._
 
 import memeid4s.UUID
-import memeid4s.cats.instances._
 import org.http4s.{ParseFailure, QueryParamDecoder, QueryParamEncoder}
 
-@SuppressWarnings(Array("scalafix:DisableSyntax.valInAbstract"))
+@SuppressWarnings(Array("scalafix:DisableSyntax.valInAbstract", "scalafix:Disable.toString"))
 trait instances {
 
   /** Allow reading UUIDs from a request's query params */
@@ -36,7 +34,7 @@ trait instances {
 
   /** Allow using UUIDs in a request's query params */
   implicit val UUIDQueryParamEncoderInstance: QueryParamEncoder[UUID] =
-    QueryParamEncoder[String].contramap(_.show)
+    QueryParamEncoder[String].contramap(_.toString)
 
 }
 

--- a/memeid4s/src/test/scala/memeid4s/SQUUIDSpec.scala
+++ b/memeid4s/src/test/scala/memeid4s/SQUUIDSpec.scala
@@ -16,6 +16,7 @@
 
 package memeid4s
 
+import collection.parallel.immutable.ParRange
 import org.specs2.mutable.Specification
 
 @SuppressWarnings(Array("scalafix:Disable.scala.parallel"))
@@ -24,15 +25,15 @@ class SQUUIDSpec extends Specification {
   "SQUUID constructor" should {
 
     "create version 4 UUIDs" in {
-      val uuids = (1 to 10).par.map(_ => UUID.V4.squuid.version)
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V4.squuid.version).toVector.toSet
 
-      uuids.to[Set] must contain(exactly(4))
+      uuids must contain(exactly(4))
     }
 
     "not generate the same UUID twice" in {
-      val uuids = (1 to 10).par.map(_ => UUID.V4.squuid)
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V4.squuid).toVector.toSet
 
-      uuids.to[Set].size must be equalTo 10
+      uuids.size must be equalTo 10
     }
 
   }

--- a/memeid4s/src/test/scala/memeid4s/V1Spec.scala
+++ b/memeid4s/src/test/scala/memeid4s/V1Spec.scala
@@ -16,6 +16,8 @@
 
 package memeid4s
 
+import scala.collection.parallel.immutable.ParRange
+
 import org.specs2.mutable.Specification
 
 @SuppressWarnings(Array("scalafix:Disable.scala.parallel"))
@@ -24,9 +26,9 @@ class V1Spec extends Specification {
   "V1 constructor" should {
 
     "create version 1 UUIDs" in {
-      val ids = (1 to 10).par.map(_ => UUID.V1.next.version)
+      val ids = new ParRange(1 to 10).map(_ => UUID.V1.next.version).toVector.toSet
 
-      ids.to[Set] must contain(exactly(1))
+      ids must contain(exactly(1))
     }
 
     "create monotonically increasing UUIDs" in {
@@ -37,13 +39,13 @@ class V1Spec extends Specification {
     }
 
     "not generate the same UUID twice" in {
-      val ids = (1 to 10).par.map(_ => UUID.V1.next).toSet
+      val ids = new ParRange(1 to 10).map(_ => UUID.V1.next).toSet
 
       ids.size must be equalTo 10
     }
 
     "not generate the same UUID twice with high concurrency" in {
-      val ids = (1 to 999).par.map(_ => UUID.V1.next).toSet
+      val ids = new ParRange(1 to 999).map(_ => UUID.V1.next).toSet
 
       ids.size must be equalTo 999
     }

--- a/memeid4s/src/test/scala/memeid4s/V4Spec.scala
+++ b/memeid4s/src/test/scala/memeid4s/V4Spec.scala
@@ -16,6 +16,8 @@
 
 package memeid4s
 
+import scala.collection.parallel.immutable.ParRange
+
 import org.specs2.mutable.Specification
 
 @SuppressWarnings(Array("scalafix:Disable.scala.parallel"))
@@ -24,15 +26,15 @@ class V4Spec extends Specification {
   "V4 constructor" should {
 
     "create version 4 UUIDs" in {
-      val uuids = (1 to 10).par.map(_ => UUID.V4.random.version)
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V4.random.version).toVector.toSet
 
-      uuids.to[Set] must contain(exactly(4))
+      uuids must contain(exactly(4))
     }
 
     "not generate the same UUID twice" in {
-      val uuids = (1 to 10).par.map(_ => UUID.V4.random)
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V4.random).toVector.toSet
 
-      uuids.to[Set].size must be equalTo 10
+      uuids.size must be equalTo 10
     }
 
     "be unable to create non-v4 values regardless of msb/lsb values provided" in {

--- a/project/WarnUnusedPlugin.scala
+++ b/project/WarnUnusedPlugin.scala
@@ -1,0 +1,19 @@
+import sbt._
+import sbt.Keys._
+import sbt.plugins.JvmPlugin
+
+/**
+ * Enables `-Ywarn-unused` in all projects.
+ * This option is now required for 2.13 scalafix's RemoveUnused rule to work.
+ */
+object WarnUnusedPlugin extends AutoPlugin {
+
+  override def requires: Plugins = JvmPlugin
+
+  override def trigger: PluginTrigger = allRequirements
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    scalacOptions += "-Ywarn-unused"
+  )
+
+}

--- a/project/WarnUnusedPlugin.scala
+++ b/project/WarnUnusedPlugin.scala
@@ -1,6 +1,7 @@
 import sbt._
 import sbt.Keys._
 import sbt.plugins.JvmPlugin
+import dependencies.on
 
 /**
  * Enables `-Ywarn-unused` in all projects.
@@ -13,7 +14,7 @@ object WarnUnusedPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    scalacOptions += "-Ywarn-unused"
+    scalacOptions ++= on(2, 13)("-Ywarn-unused").value
   )
 
 }

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -13,11 +13,13 @@ object dependencies {
     val http4s              = "0.21.1"
     val specs               = "4.8.3"
     val shapeless           = "2.3.3"
+    val `par-colls`         = "0.2.0"
 
   }
 
   val common: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.specs2" %% "specs2-scalacheck" % V.specs % Test
+    "org.specs2"             %% "specs2-scalacheck"          % V.specs       % Test,
+    "org.scala-lang.modules" %% "scala-parallel-collections" % V.`par-colls` % Test
   )
 
   val cats: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(


### PR DESCRIPTION
# What has been done in this PR?

- Simplify project hierarchy
- Make necessary changes in order to support Scala 2.13
- Add cross-compilation for both Scala `2.12.10` and `2.13.1`

# References issues

This PR closes #115 