### PR TITLE
Use range provided dependencies for integrations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ lazy val `root` = project
 
 lazy val `docs` = project
   .in(file("memeid-docs"))
-  .settings(name := "memeid")
   .enablePlugins(MdocPlugin)
+  .settings(mdocVariables += "NAME" -> "memeid")
   .settings(mdocOut := file("."))
   .settings(skip in publish := true)
   .dependsOn(allProjects.map(ClasspathDependency(_, None)): _*)

--- a/build.sbt
+++ b/build.sbt
@@ -18,42 +18,39 @@ lazy val `docs` = project
   .enablePlugins(MdocPlugin)
   .settings(mdocOut := file("."))
   .settings(skip in publish := true)
-  .settings(dependencies.docs)
   .dependsOn(allProjects.map(ClasspathDependency(_, None)): _*)
 
 lazy val `memeid` = project
   .settings(crossPaths := false)
   .settings(publishMavenStyle := true)
   .settings(autoScalaLibrary := false)
-  .settings(dependencies.common)
 
 lazy val memeid4s = project
-  .dependsOn(`memeid`, `memeid4s-scalacheck` % Test)
-  .settings(dependencies.common)
+  .dependsOn(`memeid`)
+  .dependsOn(`memeid4s-scalacheck` % Test)
 
 lazy val `memeid4s-cats` = project
-  .dependsOn(`memeid4s`, `memeid4s-scalacheck` % Test)
-  .settings(dependencies.common, dependencies.cats)
+  .dependsOn(`memeid4s`)
+  .dependsOn(`memeid4s-scalacheck` % Test)
 
 lazy val `memeid4s-literal` = project
   .dependsOn(`memeid4s`)
-  .settings(dependencies.common, dependencies.literal)
 
 lazy val `memeid4s-doobie` = project
   .dependsOn(`memeid4s`)
-  .settings(dependencies.common, dependencies.doobie)
 
 lazy val `memeid4s-circe` = project
-  .dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
-  .settings(dependencies.common, dependencies.circe)
+  .dependsOn(`memeid4s`)
+  .dependsOn(`memeid4s-cats` % Test)
+  .dependsOn(`memeid4s-scalacheck` % Test)
 
 lazy val `memeid4s-http4s` = project
-  .dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
-  .settings(dependencies.common, dependencies.http4s)
+  .dependsOn(`memeid4s`)
+  .dependsOn(`memeid4s-cats` % Test)
+  .dependsOn(`memeid4s-scalacheck` % Test)
 
 lazy val `memeid4s-scalacheck` = project
   .dependsOn(memeid)
-  .settings(dependencies.scalacheck)
 
 lazy val allProjects: Seq[ProjectReference] = Seq(
   `memeid`,

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,6 @@ lazy val memeid4s = project
 lazy val `memeid4s-cats` = project
   .dependsOn(`memeid4s`, `memeid4s-scalacheck` % Test)
   .settings(dependencies.common, dependencies.cats)
-  .settings(dependencies.compilerPlugins)
 
 lazy val `memeid4s-literal` = project
   .dependsOn(`memeid4s`)

--- a/memeid4s-cats/src/main/scala/memeid4s/cats/syntax.scala
+++ b/memeid4s-cats/src/main/scala/memeid4s/cats/syntax.scala
@@ -30,17 +30,17 @@ trait syntax {
 
   implicit class UUIDtoCatsConstructors(companion: UUID.type) {
 
-    def v1[F[_]: Sync](implicit N: Node, T: Time): F[UUID] = F.delay(UUID.V1.next(N, T))
+    def v1[F[_]: Sync](implicit N: Node, T: Time): F[UUID] = Sync[F].delay(UUID.V1.next(N, T))
 
     def v3[F[_]: Sync, A: Digestible](namespace: UUID, local: A): F[UUID] =
-      F.delay(UUID.V3(namespace, local))
+      Sync[F].delay(UUID.V3(namespace, local))
 
     def v5[F[_]: Sync, A: Digestible](namespace: UUID, local: A): F[UUID] =
-      F.delay(UUID.V5(namespace, local))
+      Sync[F].delay(UUID.V5(namespace, local))
 
-    def random[F[_]: Sync]: F[UUID] = F.delay(UUID.V4.random)
+    def random[F[_]: Sync]: F[UUID] = Sync[F].delay(UUID.V4.random)
 
-    def squuid[F[_]: Sync: Clock]: F[UUID] = F.realTime(SECONDS).map { s =>
+    def squuid[F[_]: Sync: Clock]: F[UUID] = Clock[F].realTime(SECONDS).map { s =>
       UUID.V4.squuid {
         new Posix {
           override def value: Long = s

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -59,8 +59,11 @@ object dependencies {
   )
 
   val docs: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.tpolecat" %% "doobie-h2"  % "0.8.8",
-    "org.http4s"   %% "http4s-dsl" % "0.21.1"
+    "org.typelevel"  %% "cats-effect" % "2.1.1",
+    "io.circe"       %% "circe-core"  % "0.13.0",
+    "org.tpolecat"   %% "doobie-h2"   % "0.8.8",
+    "org.http4s"     %% "http4s-dsl"  % "0.21.1",
+    "org.scalacheck" %% "scalacheck"  % "1.14.3"
   )
 
   /**

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -5,62 +5,62 @@ object dependencies {
 
   object V {
 
-    val cats                = "2.1.1"
-    val `cats-laws`         = "2.1.0"
-    val circe               = "0.13.0"
-    val `discipline-specs2` = "1.0.0"
-    val doobie              = "0.8.8"
-    val http4s              = "0.21.1"
-    val specs               = "4.8.3"
-    val shapeless           = "2.3.3"
-    val `par-colls`         = "0.2.0"
+    val cats = "2.1.1"
+
+    val circe = "0.13.0"
+
+    val doobie = "0.8.8"
+
+    val http4s = "0.21.1"
+
+    val scalacheck = "1.14.3"
 
   }
 
   val common: Seq[Def.Setting[Seq[ModuleID]]] = Seq(
-    libraryDependencies += "org.specs2" %% "specs2-scalacheck" % V.specs % Test,
+    libraryDependencies += "org.specs2" %% "specs2-scalacheck" % "4.8.3" % Test,
     libraryDependencies ++= on(2, 13) {
-      "org.scala-lang.modules" %% "scala-parallel-collections" % V.`par-colls` % Test
+      "org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0" % Test
     }.value
   )
 
   val cats: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
     "org.typelevel" %% "cats-effect"       % V.cats,
-    "org.typelevel" %% "cats-laws"         % V.`cats-laws` % Test,
-    "org.typelevel" %% "discipline-specs2" % V.`discipline-specs2` % Test,
-    "org.specs2"    %% "specs2-cats"       % V.specs % Test
+    "org.typelevel" %% "cats-laws"         % "2.1.0" % Test,
+    "org.typelevel" %% "discipline-specs2" % "1.0.0" % Test,
+    "org.specs2"    %% "specs2-cats"       % "4.8.3" % Test
   )
 
   val literal: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
-    "com.chuusai"    %% "shapeless"    % V.shapeless        % Test
+    "com.chuusai"    %% "shapeless"    % "2.3.3"            % Test
   )
 
   val doobie: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
     "org.tpolecat" %% "doobie-core"   % V.doobie,
-    "org.tpolecat" %% "doobie-specs2" % V.doobie % Test,
-    "org.tpolecat" %% "doobie-h2"     % V.doobie % Test,
-    "org.specs2"   %% "specs2-cats"   % V.specs % Test
+    "org.tpolecat" %% "doobie-specs2" % "0.8.8" % Test,
+    "org.tpolecat" %% "doobie-h2"     % "0.8.8" % Test,
+    "org.specs2"   %% "specs2-cats"   % "4.8.3" % Test
   )
 
   val circe: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
     "io.circe"      %% "circe-core"        % V.circe,
-    "org.typelevel" %% "discipline-specs2" % V.`discipline-specs2` % Test,
-    "io.circe"      %% "circe-testing"     % V.circe % Test
+    "org.typelevel" %% "discipline-specs2" % "1.0.0" % Test,
+    "io.circe"      %% "circe-testing"     % "0.13.0" % Test
   )
 
   val http4s: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
     "org.http4s" %% "http4s-core" % V.http4s,
-    "org.http4s" %% "http4s-dsl"  % V.http4s % Test
+    "org.http4s" %% "http4s-dsl"  % "0.21.1" % Test
   )
 
   val scalacheck: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.scalacheck" %% "scalacheck" % "1.14.3"
+    "org.scalacheck" %% "scalacheck" % V.scalacheck
   )
 
   val docs: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.tpolecat" %% "doobie-h2"  % V.doobie,
-    "org.http4s"   %% "http4s-dsl" % V.http4s
+    "org.tpolecat" %% "doobie-h2"  % "0.8.8",
+    "org.http4s"   %% "http4s-dsl" % "0.21.1"
   )
 
   /**

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -63,10 +63,6 @@ object dependencies {
     "org.http4s"   %% "http4s-dsl" % V.http4s
   )
 
-  val compilerPlugins: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    compilerPlugin("org.augustjune" %% "context-applied" % "0.1.2")
-  )
-
   /**
    * Wraps the value in a `Seq` if current scala version matches the one provided,
    * otherwise returns `Nil`.

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -5,15 +5,27 @@ object dependencies {
 
   object V {
 
-    val cats = "2.1.1"
+    val `cats-effect` = on {
+      case (2, 12) => "[0.2,)"
+      case (2, 13) => "[2.0.0,)"
+    }
 
-    val circe = "0.13.0"
+    val circe = on {
+      case (2, 12) => "[0.6.0,)"
+      case (2, 13) => "[0.12.0,)"
+    }
 
-    val doobie = "0.8.8"
+    val doobie = on {
+      case (2, 12) => "[0.4.0,)"
+      case (2, 13) => "[0.8.2,)"
+    }
 
-    val http4s = "0.21.1"
+    val http4s = on {
+      case (2, 12) => "[0.15.0,)"
+      case (2, 13) => "[0.21.0,)"
+    }
 
-    val scalacheck = "1.14.3"
+    val scalacheck = "[1.14.0,)"
 
   }
 
@@ -25,10 +37,10 @@ object dependencies {
   )
 
   val cats: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-effect"       % V.cats  % Provided,
-    "org.typelevel" %% "cats-laws"         % "2.1.0" % Test,
-    "org.typelevel" %% "discipline-specs2" % "1.0.0" % Test,
-    "org.specs2"    %% "specs2-cats"       % "4.8.3" % Test
+    "org.typelevel" %% "cats-effect"       % V.`cats-effect`.value % Provided,
+    "org.typelevel" %% "cats-laws"         % "2.1.0"               % Test,
+    "org.typelevel" %% "discipline-specs2" % "1.0.0"               % Test,
+    "org.specs2"    %% "specs2-cats"       % "4.8.3"               % Test
   )
 
   val literal: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
@@ -37,21 +49,21 @@ object dependencies {
   )
 
   val doobie: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.tpolecat" %% "doobie-core"   % V.doobie % Provided,
-    "org.tpolecat" %% "doobie-specs2" % "0.8.8"  % Test,
-    "org.tpolecat" %% "doobie-h2"     % "0.8.8"  % Test,
-    "org.specs2"   %% "specs2-cats"   % "4.8.3"  % Test
+    "org.tpolecat" %% "doobie-core"   % V.doobie.value % Provided,
+    "org.tpolecat" %% "doobie-specs2" % "0.8.8"        % Test,
+    "org.tpolecat" %% "doobie-h2"     % "0.8.8"        % Test,
+    "org.specs2"   %% "specs2-cats"   % "4.8.3"        % Test
   )
 
   val circe: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "io.circe"      %% "circe-core"        % V.circe  % Provided,
-    "org.typelevel" %% "discipline-specs2" % "1.0.0"  % Test,
-    "io.circe"      %% "circe-testing"     % "0.13.0" % Test
+    "io.circe"      %% "circe-core"        % V.circe.value % Provided,
+    "org.typelevel" %% "discipline-specs2" % "1.0.0"       % Test,
+    "io.circe"      %% "circe-testing"     % "0.13.0"      % Test
   )
 
   val http4s: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.http4s" %% "http4s-core" % V.http4s % Provided,
-    "org.http4s" %% "http4s-dsl"  % "0.21.1" % Test
+    "org.http4s" %% "http4s-core" % V.http4s.value % Provided,
+    "org.http4s" %% "http4s-dsl"  % "0.21.1"       % Test
   )
 
   val scalacheck: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
@@ -65,6 +77,17 @@ object dependencies {
     "org.http4s"     %% "http4s-dsl"  % "0.21.1",
     "org.scalacheck" %% "scalacheck"  % "1.14.3"
   )
+
+  /**
+   * Wraps the value in a `Seq` if current scala version matches the one provided,
+   * otherwise returns `Nil`.
+   */
+  def on[A](pf: PartialFunction[(Long, Long), String]): Def.Initialize[String] = Def.setting {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some(v) => pf(v)
+      case _       => sys.error("Invalid Scala version")
+    }
+  }
 
   /**
    * Wraps the value in a `Seq` if current scala version matches the one provided,

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -25,7 +25,7 @@ object dependencies {
   )
 
   val cats: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-effect"       % V.cats,
+    "org.typelevel" %% "cats-effect"       % V.cats  % Provided,
     "org.typelevel" %% "cats-laws"         % "2.1.0" % Test,
     "org.typelevel" %% "discipline-specs2" % "1.0.0" % Test,
     "org.specs2"    %% "specs2-cats"       % "4.8.3" % Test
@@ -37,25 +37,25 @@ object dependencies {
   )
 
   val doobie: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.tpolecat" %% "doobie-core"   % V.doobie,
-    "org.tpolecat" %% "doobie-specs2" % "0.8.8" % Test,
-    "org.tpolecat" %% "doobie-h2"     % "0.8.8" % Test,
-    "org.specs2"   %% "specs2-cats"   % "4.8.3" % Test
+    "org.tpolecat" %% "doobie-core"   % V.doobie % Provided,
+    "org.tpolecat" %% "doobie-specs2" % "0.8.8"  % Test,
+    "org.tpolecat" %% "doobie-h2"     % "0.8.8"  % Test,
+    "org.specs2"   %% "specs2-cats"   % "4.8.3"  % Test
   )
 
   val circe: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "io.circe"      %% "circe-core"        % V.circe,
-    "org.typelevel" %% "discipline-specs2" % "1.0.0" % Test,
+    "io.circe"      %% "circe-core"        % V.circe  % Provided,
+    "org.typelevel" %% "discipline-specs2" % "1.0.0"  % Test,
     "io.circe"      %% "circe-testing"     % "0.13.0" % Test
   )
 
   val http4s: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.http4s" %% "http4s-core" % V.http4s,
+    "org.http4s" %% "http4s-core" % V.http4s % Provided,
     "org.http4s" %% "http4s-dsl"  % "0.21.1" % Test
   )
 
   val scalacheck: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(
-    "org.scalacheck" %% "scalacheck" % V.scalacheck
+    "org.scalacheck" %% "scalacheck" % V.scalacheck % Provided
   )
 
   val docs: Def.Setting[Seq[ModuleID]] = libraryDependencies ++= Seq(


### PR DESCRIPTION
# What has been done in this PR?

- Change all integration dependencies to a `Provided` range:

```scala
//from this:
libraryDependencies += "org.typelevel" %% "cats-effect" % "2.1.1"

//to this:
val `cats-effect` = on {
  case (2, 12) => "[0.2,)"
  case (2, 13) => "[2.0.0,)"
}

libraryDependencies += "org.typelevel" %% "cats-effect" % `cats-effect`
```

With ranges as wide as possible, from the first version possible (that compiles with current code) to the latest version.

Since [`scala-steward`](https://github.com/fthomas/scala-steward) is going to update versions in `docs` project, we can check if a new version of the library stops compiling and in that case, we'll need to release a new version upgrading the range.

## Other changes

- Remove [`context-applied`](https://github.com/augustjune/context-applied) compiler plugin, until support for IDEs is added.
- Convert `dependencies` object into an auto plugin to simplify dependency management with something like:

```scala
override def projectSettings: Seq[Def.Setting[_]] = Seq(
  libraryDependencies ++= projectID.value.name match {
    case "docs"             => docs
    case "memeid4s-cats"    => cats.value
    case "memeid4s-literal" => literal.value
    case "memeid4s-doobie"  => doobie.value
    case _                  => Nil
  }
)
```

## References

[Maven Version Range References](https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN8903)