### PR TITLE
Range versions should not be updated by scala steward

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -4,6 +4,7 @@ import sbt.plugins.JvmPlugin
 
 object dependencies extends AutoPlugin {
 
+  // scala-steward:off
   object V {
 
     val `cats-effect` = on {
@@ -29,6 +30,7 @@ object dependencies extends AutoPlugin {
     val scalacheck = "[1.14.0,)"
 
   }
+  // scala-steward:on
 
   private val common = Seq("org.specs2" %% "specs2-scalacheck" % "4.8.3" % Test)
 


### PR DESCRIPTION
Add markers to tell [scala-steward](https://github.com/fthomas/scala-steward) not to update version ranges, only fixed versions, as stated in [its documentation](https://github.com/fthomas/scala-steward/blob/master/docs/repo-specific-configuration.md#ignore-lines).

This will avoid PRs like: https://github.com/47degrees/memeid/pull/125

![](https://user-images.githubusercontent.com/9027541/75229537-68aa2e00-57b2-11ea-9946-f9b7c0f5e4e9.png)
