### PR TITLE
Auto merge all scala-steward's PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,6 @@ pull_request_rules:
     conditions:
       - author=scala-steward
       - status-success=test
-      - body~=labels:.*semver-patch
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Since the only versions updated by scala-steward are those for `Test` configuration or `docs` module, we can safely auto-update all scala-steward's PRs that pass the Github Actions tests