### PR TITLE
Validate string before calling java.util.fromString

### DIFF
--- a/memeid/src/main/java/memeid/UUID.java
+++ b/memeid/src/main/java/memeid/UUID.java
@@ -82,7 +82,10 @@ public class UUID implements Comparable<UUID> {
      *                                  described in {@link #toString}
      */
     public static UUID fromString(String name) {
-        return fromUUID(java.util.UUID.fromString(name));
+        if (name.matches("[\\da-fA-F]{8}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{4}-[\\da-fA-F]{12}"))
+            return fromUUID(java.util.UUID.fromString(name));
+        else
+            throw new IllegalArgumentException("Invalid UUID string: "+name);
     }
 
     /**

--- a/memeid/src/test/scala/memeid/UUIDSpec.scala
+++ b/memeid/src/test/scala/memeid/UUIDSpec.scala
@@ -32,6 +32,10 @@ class UUIDSpec extends Specification with ScalaCheck {
       UUID.fromString(uuid.toString) should be equalTo uuid
     }
 
+    "throw exception on an invalid string that is accepted by java.util.fromString" >> {
+      UUID.fromString("1-1-1-1-1") must throwAn[IllegalArgumentException]
+    }
+
     "throw exception on invalid string" in prop { s: String =>
       UUID.fromString(s) must throwAn[IllegalArgumentException]
     }.setGen(Gen.alphaNumStr)


### PR DESCRIPTION
Applying this PR will validate the string to check if it follows RFC 4122 using a regex before calling `java.util.fromString`. Fixes https://github.com/47degrees/memeid/issues/134.
 
Comments welcome as I'm not a java programmer. :)