### PR TITLE
More efficient parsing of UUIDs from strings

### DIFF
--- a/bench/src/main/scala/UUIDBench.scala
+++ b/bench/src/main/scala/UUIDBench.scala
@@ -1,8 +1,7 @@
 package memeid4s.bench
 
+import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
-
-import scala.util.Random
 
 import memeid4s.UUID
 import org.openjdk.jmh.annotations._
@@ -10,17 +9,14 @@ import org.openjdk.jmh.annotations._
 object UUIDStates {
   val namespace = UUID.V1.next
 
-  val gen = new Random()
-
   @SuppressWarnings(Array("scalafix:Disable.toString"))
-  val uuids: List[String] = (1 to 100).map(_ => UUID.V1.next.toString).toList
+  val uuids: Array[String] = (1 to 100).map(_ => UUID.V1.next.toString).toArray
 
   @State(Scope.Benchmark)
   class RNG {
-
-    def uuid: String =
-      uuids(gen.nextInt(uuids.length))
+    def uuid: String = uuids(ThreadLocalRandom.current().nextInt(uuids.length))
   }
+
 }
 
 @Warmup(
@@ -34,6 +30,7 @@ object UUIDStates {
   timeUnit = TimeUnit.SECONDS
 )
 class UUIDBenchmark {
+
   import UUIDStates._
 
   @Benchmark


### PR DESCRIPTION
## Before
#### Corretto 8
```
[info] Benchmark                  Mode  Cnt       Score      Error  Units
[info] UUIDBenchmark.fromString  thrpt   15  948839.022 ± 7011.880  ops/s
```
#### Corretto 11
```
[info] Benchmark                  Mode  Cnt        Score       Error  Units
[info] UUIDBenchmark.fromString  thrpt   15  1500465.570 ± 11592.723  ops/s
```
#### OpenJDK 15
```
[info] Benchmark                  Mode  Cnt        Score       Error  Units
[info] UUIDBenchmark.fromString  thrpt   15  1826314.320 ± 33815.069  ops/s
```
## After
#### Corretto 8
```
[info] Benchmark                  Mode  Cnt         Score       Error  Units
[info] UUIDBenchmark.fromString  thrpt   15  21568831.647 ± 83625.539  ops/s
```
#### Corretto 11
```
[info] Benchmark                  Mode  Cnt         Score       Error  Units
[info] UUIDBenchmark.fromString  thrpt   15  23971815.448 ± 35417.588  ops/s
```
#### OpenJDK 15
```
[info] Benchmark                  Mode  Cnt         Score       Error  Units
[info] UUIDBenchmark.fromString  thrpt   15  27989191.275 ± 37117.812  ops/s
```
