### PR TITLE
Sbt Hood CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     runs-on: ubuntu-latest
+    env:
+      REQUIRES_JEKYLL_CI: ${{secrets.REQUIRES_JEKYLL_CI}}
+      REQUIRES_CODECOV: ${{secrets.REQUIRES_CODECOV}}
+      PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Checkout project (pull-request)
         if: github.event_name == 'pull_request'

--- a/bench/master.avgtime.csv
+++ b/bench/master.avgtime.csv
@@ -1,7 +1,0 @@
-"Benchmark","Mode","Threads","Samples","Score","Score Error (99.9%)","Unit"
-"memeid4s.bench.UUIDBenchmark.fromString","avgt",1,75,685.983479,53.769669,"ns/op"
-"memeid4s.bench.UUIDBenchmark.namespacedV3","avgt",1,75,597.768306,21.961928,"ns/op"
-"memeid4s.bench.UUIDBenchmark.namespacedV5","avgt",1,75,745.082478,11.578711,"ns/op"
-"memeid4s.bench.UUIDBenchmark.random","avgt",1,75,445.831089,31.298754,"ns/op"
-"memeid4s.bench.UUIDBenchmark.squuid","avgt",1,75,446.353216,9.494642,"ns/op"
-"memeid4s.bench.UUIDBenchmark.timeBased","avgt",1,75,1000.674435,0.875659,"ns/op"

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / scalaVersion       := "2.13.3"
 ThisBuild / crossScalaVersions := Seq("2.12.12", "2.13.3")
 ThisBuild / organization       := "com.47deg"
 
-addCommandAlias("ci-test", "fix --check; +mdoc; testCovered; generateMasterFile; compareBenchmarksCI")
+addCommandAlias("ci-test", "fix --check; +mdoc; testCovered; runAvgtime; generateMasterFile; compareBenchmarksCI")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll; publishMicrosite")
 addCommandAlias("ci-publish", "github; ci-release")
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / scalaVersion       := "2.13.3"
 ThisBuild / crossScalaVersions := Seq("2.12.12", "2.13.3")
 ThisBuild / organization       := "com.47deg"
 
-addCommandAlias("ci-test", "fix --check; +mdoc; testCovered")
+addCommandAlias("ci-test", "fix --check; +mdoc; testCovered; generateMasterFile; compareBenchmarksCI")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll; publishMicrosite")
 addCommandAlias("ci-publish", "github; ci-release")
 
@@ -54,10 +54,10 @@ lazy val bench = project
   .enablePlugins(HoodPlugin)
 
 val runAvgtimeCmd =
-  "bench/jmh:run -i 15 -wi 15 -bm AverageTime -tu ns"
+  "bench/jmh:run -i 10 -wi 5 -bm AverageTime -tu ns"
 
 val runThroughputCmd =
-  "bench/jmh:run -i 15 -wi 15 -bm Throughput -tu s"
+  "bench/jmh:run -i 10 -wi 5 -bm Throughput -tu s"
 
 addCommandAlias(
   "runAvgtime",
@@ -85,3 +85,12 @@ addCommandAlias(
     " -rff current.throughput.prof.csv" +
     " -prof stack;"
 )
+
+val generateMasterFileTask =
+  taskKey[Unit]("If the master file has not been created, current is copied. This will happen just the first time.")
+generateMasterFileTask := {
+  if (!file("bench/master.avgtime.csv").exists())
+    IO.copy(Seq((file("bench/current.avgtime.csv"), file("bench/master.avgtime.csv"))))
+}
+
+addCommandAlias("generateMasterFile", ";" + generateMasterFileTask.key)

--- a/build.sbt
+++ b/build.sbt
@@ -86,11 +86,9 @@ addCommandAlias(
     " -prof stack;"
 )
 
-val generateMasterFileTask =
+val generateMasterFile =
   taskKey[Unit]("If the master file has not been created, current is copied. This will happen just the first time.")
-generateMasterFileTask := {
+generateMasterFile := {
   if (!file("bench/master.avgtime.csv").exists())
     IO.copy(Seq((file("bench/current.avgtime.csv"), file("bench/master.avgtime.csv"))))
 }
-
-addCommandAlias("generateMasterFile", ";" + generateMasterFileTask.key)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,10 @@ ThisBuild / scalaVersion       := "2.13.3"
 ThisBuild / crossScalaVersions := Seq("2.12.12", "2.13.3")
 ThisBuild / organization       := "com.47deg"
 
-addCommandAlias("ci-test", "fix --check; +mdoc; testCovered; runAvgtime; generateMasterFile; compareBenchmarksCI")
+addCommandAlias(
+  "ci-test",
+  "fix --check; +mdoc; testCovered; runAvgtime; generateMasterFile; compareBenchmarksCI; uploadBenchmarks"
+)
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll; publishMicrosite")
 addCommandAlias("ci-publish", "github; ci-release")
 

--- a/project/HoodPlugin.scala
+++ b/project/HoodPlugin.scala
@@ -17,6 +17,9 @@ object HoodPlugin extends AutoPlugin {
       repositoryName        := Option("memeid"),
       pullRequestNumber     := Option(System.getenv().get("PULL_REQUEST_NUMBER")).map(_.toInt),
       outputToFile          := true,
-      outputPath            := file("bench/comparison.md")
+      outputPath            := file("bench/comparison.md"),
+      benchmarkFiles        := List(file("bench/current.avgtime.csv")),
+      uploadDirectory       := "bench",
+      commitMessage         := "Update benchmark file"
     )
 }

--- a/project/HoodPlugin.scala
+++ b/project/HoodPlugin.scala
@@ -15,6 +15,8 @@ object HoodPlugin extends AutoPlugin {
       token                 := Option(System.getenv().get("GITHUB_TOKEN")),
       repositoryOwner       := Option("47degrees"),
       repositoryName        := Option("memeid"),
-      pullRequestNumber     := Option(System.getenv().get("PULL_REQUEST_NUMBER")).map(_.toInt)
+      pullRequestNumber     := Option(System.getenv().get("PULL_REQUEST_NUMBER")).map(_.toInt),
+      outputToFile          := true,
+      outputPath            := file("bench/comparison.md")
     )
 }


### PR DESCRIPTION
# What has been done in this PR?
This PR adds the benchmarking comparison between master benchmark data and the candidate PR.
The main changes are:

- Get PR number in the ci action. This is done in this repo for the moment. If it works properly, it will probably added to https://github.com/47degrees/.github/blob/master/workflows/ci.yml 

- Add Sbt-Hood's `compareBenchmarksCI` task. Before that, it's checked that `master.avgtime.csv` exists. Actually, this will be done just for the first time. 

- Jmh iterations have been reduce for avoiding a very slow ci procedure.