### PR TITLE
Add integration module with `Tapir`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,6 +35,7 @@ lazy val `memeid4s-literal`    = module.dependsOn(`memeid4s`)
 lazy val `memeid4s-doobie`     = module.dependsOn(`memeid4s`)
 lazy val `memeid4s-circe`      = module.dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
 lazy val `memeid4s-http4s`     = module.dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
+lazy val `memeid4s-tapir`      = module.dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
 lazy val `memeid4s-scalacheck` = module.dependsOn(memeid)
 
 lazy val bench = project

--- a/docs/README.md
+++ b/docs/README.md
@@ -266,6 +266,23 @@ HttpRoutes.of[IO] {
 }
 ```
 
+##### Tapir
+
+```scala
+libraryDependencies += "com.47deg" %% "memeid4s-tapir" % "@VERSION@"
+```
+
+The [Tapir](https://tapir.softwaremill.com/en/latest/) integration provides implicit instances for `Codec[UUID]` and `Schema[UUID]`, which allow using `UUID` as 
+type for query/path params or headers in endpoints. As well as enriching documentation when a `UUID` field is used.
+
+```scala mdoc:silent
+import memeid4s.tapir.implicits._
+
+import sttp.tapir._
+
+endpoint.get.in("hello" / path[UUID])
+```
+
 ##### Cats & Cats-effect
 
 ```scala

--- a/microsite/docs/docs/memeid4s_tapir.md
+++ b/microsite/docs/docs/memeid4s_tapir.md
@@ -1,0 +1,23 @@
+---
+layout: docs
+title: memeid4s-tapir
+permalink: docs/memeid4s_tapir/
+---
+
+##### Tapir
+
+```scala
+libraryDependencies += "com.47deg" %% "memeid4s-tapir" % "@VERSION@"
+```
+
+The [Tapir](https://tapir.softwaremill.com/en/latest/) integration provides implicit instances for `Codec[UUID]` and `Schema[UUID]`, which allow using `UUID` as 
+type for query/path params or headers in endpoints. As well as enriching documentation when a `UUID` field is used.
+
+```scala mdoc:silent
+import memeid4s.UUID
+import memeid4s.tapir.implicits._
+
+import sttp.tapir._
+
+endpoint.get.in("hello" / path[UUID])
+```

--- a/microsite/docs/index.md
+++ b/microsite/docs/index.md
@@ -2,5 +2,5 @@
 layout: homeFeatures
 features:
  - first:   ["RFC-compliant ", "memeid provides Time-based(v1), Random(v4), Namespaced(v3, v5) and Semi-sequential, random(SQUUID) UUID generation"]
- - second:  ["Third Party Integration", "memeid provides several modules that integrate with popular third-party libraries like Dobbie, Circe, Http4s and Cats."]
+ - second:  ["Third Party Integration", "memeid provides several modules that integrate with popular third-party libraries like Dobbie, Circe, Http4s, Tapir and Cats."]
 ---

--- a/microsite/src/main/resources/microsite/data/menu.yml
+++ b/microsite/src/main/resources/microsite/data/menu.yml
@@ -1,5 +1,4 @@
 options:
-
   - title: Quickstart
     url: docs/
 
@@ -12,6 +11,8 @@ options:
         url: docs/memeid4s_circe/
       - title: Http4s
         url: docs/memeid4s_http4s/
+      - title: Tapir
+        url: docs/memeid4s_tapir/
       - title: Cats & Cats-effect
         url: docs/memeid4s_cats/
       - title: Scalacheck

--- a/modules/memeid4s-tapir/src/main/scala/memeid4s/tapir/implicits.scala
+++ b/modules/memeid4s-tapir/src/main/scala/memeid4s/tapir/implicits.scala
@@ -1,0 +1,3 @@
+package memeid4s.tapir
+
+object implicits extends instances

--- a/modules/memeid4s-tapir/src/main/scala/memeid4s/tapir/instances.scala
+++ b/modules/memeid4s-tapir/src/main/scala/memeid4s/tapir/instances.scala
@@ -1,0 +1,28 @@
+package memeid4s.tapir
+
+import memeid4s.UUID
+import sttp.tapir.Codec
+import sttp.tapir.CodecFormat
+import sttp.tapir.DecodeResult
+import sttp.tapir.Schema
+import sttp.tapir.SchemaType.SString
+
+@SuppressWarnings(Array("scalafix:DisableSyntax.valInAbstract"))
+trait instances {
+
+  /**
+   * Allows reading `UUID` values from path, query params, or headers
+   */
+  implicit val UUIDCodec: Codec[String, UUID, CodecFormat.TextPlain] =
+    Codec.string
+      .mapDecode(s => UUID.from(s).fold(DecodeResult.Error(s, _), DecodeResult.Value(_)))(_.toString) // scalafix:ok
+      .modifySchema(_.format("uuid"))
+
+  /**
+   * Provides a valid `Schema` for `UUID` type, to be used when generating documentation.
+   */
+  implicit val UUIDSchema: Schema[UUID] = Schema(SString).format("uuid")
+
+}
+
+object instances extends instances

--- a/modules/memeid4s-tapir/src/test/scala/memeid4s/tapir/InstancesSpec.scala
+++ b/modules/memeid4s-tapir/src/test/scala/memeid4s/tapir/InstancesSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019-2020 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memeid4s.tapir
+
+import cats.syntax.show._
+
+import memeid4s.UUID
+import memeid4s.cats.implicits._
+import memeid4s.scalacheck.arbitrary.instances._
+import memeid4s.tapir.implicits._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+import sttp.tapir._
+import sttp.tapir.docs.openapi._
+import sttp.tapir.openapi.circe.yaml._
+
+class InstancesSpec extends Specification with ScalaCheck {
+
+  "Schema[UUID] & Codec[UUID]" should {
+
+    "provide correct schema when generating documentation" in {
+      val testEndpoint = endpoint.get.in("hello" / path[UUID])
+
+      val result = testEndpoint.toOpenAPI("", "").toYaml
+
+      val expected =
+        """openapi: 3.0.1
+          |info:
+          |  title: ''
+          |  version: ''
+          |paths:
+          |  /hello/{p1}:
+          |    get:
+          |      operationId: getHelloP1
+          |      parameters:
+          |      - name: p1
+          |        in: path
+          |        required: true
+          |        schema:
+          |          type: string
+          |          format: uuid
+          |      responses:
+          |        '200':
+          |          description: ''
+          |""".stripMargin
+
+      result must be equalTo expected
+    }
+
+    "validates a valid UUID" in prop { uuid: UUID =>
+      val result = UUIDCodec.decode(uuid.show)
+
+      result must be equalTo DecodeResult.Value(uuid)
+    }
+
+    "validates an invalid UUID" in {
+      val result = UUIDCodec.decode("miau")
+
+      result must be like {
+        case DecodeResult.Error("miau", e: IllegalArgumentException) =>
+          e.getMessage() must be equalTo "Invalid UUID string: miau"
+      }
+    }
+
+  }
+
+}

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -93,11 +93,12 @@ object dependencies extends AutoPlugin {
   )
 
   private val documentation = Seq(
-    "org.typelevel"  %% "cats-effect" % "2.2.0",
-    "io.circe"       %% "circe-core"  % "0.13.0",
-    "org.tpolecat"   %% "doobie-h2"   % "0.9.2",
-    "org.http4s"     %% "http4s-dsl"  % "0.21.7",
-    "org.scalacheck" %% "scalacheck"  % "1.14.3"
+    "org.typelevel"               %% "cats-effect" % "2.2.0",
+    "io.circe"                    %% "circe-core"  % "0.13.0",
+    "org.tpolecat"                %% "doobie-h2"   % "0.9.2",
+    "org.http4s"                  %% "http4s-dsl"  % "0.21.7",
+    "org.scalacheck"              %% "scalacheck"  % "1.14.3",
+    "com.softwaremill.sttp.tapir" %% "tapir-core"  % "0.16.16"
   )
 
   override def trigger: PluginTrigger = allRequirements

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -29,6 +29,8 @@ object dependencies extends AutoPlugin {
 
     val scalacheck = "[1.14.0,)"
 
+    val tapir = "[0.16.0,)"
+
   }
   // scala-steward:on
 
@@ -78,6 +80,14 @@ object dependencies extends AutoPlugin {
     )
   }
 
+  private val tapir = Def.setting {
+    Seq(
+      "com.softwaremill.sttp.tapir" %% "tapir-core"               % V.tapir   % Provided,
+      "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs"       % "0.16.16" % Test,
+      "com.softwaremill.sttp.tapir" %% "tapir-openapi-circe-yaml" % "0.16.16" % Test
+    )
+  }
+
   private val scalacheck = Seq(
     "org.scalacheck" %% "scalacheck" % V.scalacheck % Provided
   )
@@ -106,6 +116,7 @@ object dependencies extends AutoPlugin {
           case "memeid4s-doobie"     => doobie.value
           case "memeid4s-circe"      => circe.value
           case "memeid4s-http4s"     => http4s.value
+          case "memeid4s-tapir"      => tapir.value
           case "memeid4s-scalacheck" => scalacheck
           case _                     => Nil
         }

--- a/project/descriptions.scala
+++ b/project/descriptions.scala
@@ -18,6 +18,7 @@ object descriptions extends AutoPlugin {
     "memeid4s-doobie"     -> "Doobie type-classes instances to enable using memeid's UUID in doobie queries",
     "memeid4s-circe"      -> "Circe type-classes instances to enable decoding/encoding memeid's UUID values in JSON",
     "memeid4s-http4s"     -> "Http4s type-classes instances to enable using memeid's UUID as a query param in http4s services",
+    "memeid4s-tapir"      -> "Tapir type-classes instances to enable using memeid's UUID as path/query param or headers in tapir's endpoints as well as richer documentation",
     "memeid4s-scalacheck" -> "Arbitrary instances for memeid's UUID as well as the different UUID versions"
   )
 


### PR DESCRIPTION
From its own website...

> With [tapir](https://tapir.softwaremill.com/en/latest/) you can describe HTTP API endpoints as immutable Scala values. Each endpoint can contain a number of input parameters, error-output parameters, and normal-output parameters

This new module adds a bunch of implicit instances to allow using memeid's `UUID` as path/query params or headers values, as well as enriching auto-generated documentation for `UUID` fields.