### PR TITLE
Integration module between FUUID/memeid

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val `memeid4s-doobie`     = module.dependsOn(`memeid4s`)
 lazy val `memeid4s-circe`      = module.dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
 lazy val `memeid4s-http4s`     = module.dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
 lazy val `memeid4s-tapir`      = module.dependsOn(`memeid4s`, `memeid4s-cats` % Test, `memeid4s-scalacheck` % Test)
+lazy val `memeid4s-fuuid`      = module.dependsOn(`memeid4s`, `memeid4s-scalacheck` % Test)
 lazy val `memeid4s-scalacheck` = module.dependsOn(memeid)
 
 lazy val bench = project

--- a/docs/README.md
+++ b/docs/README.md
@@ -283,6 +283,39 @@ import sttp.tapir._
 endpoint.get.in("hello" / path[UUID])
 ```
 
+##### FUUID
+
+```scala
+libraryDependencies += "com.47deg" %% "memeid4s-fuuid" % "@VERSION@"
+```
+
+The [FUUID](https://christopherdavenport.github.io/fuuid/) integration provides both semi (via extension methods) and auto conversions between memeid's `UUID` type and `FUUID`.
+
+```scala mdoc:reset:silent
+import memeid4s.UUID
+import io.chrisdavenport.fuuid.FUUID
+import memeid4s.fuuid.syntax._
+
+val fuuid: FUUID = UUID.V4.random.toFUUID
+
+val uuid: UUID = fuuid.toUUID
+```
+
+```scala mdoc:reset:silent
+import memeid4s.UUID
+import io.chrisdavenport.fuuid.FUUID
+import memeid4s.fuuid.auto._
+
+def usingFUUID(fuuid: FUUID) = fuuid
+def usingUUID(uuid: UUID) = uuid
+
+val uuid: UUID = UUID.V4.random
+val fuuid: FUUID = FUUID.fromUUID(java.util.UUID.randomUUID)
+
+usingFUUID(uuid)
+usingUUID(fuuid)
+```
+
 ##### Cats & Cats-effect
 
 ```scala
@@ -296,6 +329,7 @@ The cats integration provides typeclass implementation for `UUID`, as well as ef
 ```scala mdoc:silent
 import cats._
 import memeid4s.cats.implicits._
+import cats.effect.IO
 
 Order[UUID]
 Hash[UUID]
@@ -307,6 +341,9 @@ Show[UUID]
 
 ```scala mdoc:silent
 UUID.random[IO]
+
+val namespace = UUID.V4.random
+
 UUID.v3[IO, String](namespace, "my-secret-code")
 UUID.v5[IO, String](namespace, "my-secret-code")
 ```

--- a/microsite/docs/docs/memeid4s_fuuid.md
+++ b/microsite/docs/docs/memeid4s_fuuid.md
@@ -1,0 +1,38 @@
+---
+layout: docs
+title: memeid4s-fuuid
+permalink: docs/memeid4s_fuuid/
+---
+
+##### FUUID
+
+```scala
+libraryDependencies += "com.47deg" %% "memeid4s-fuuid" % "@VERSION@"
+```
+
+The [FUUID](https://christopherdavenport.github.io/fuuid/) integration provides both semi (via extension methods) and auto conversions between memeid's `UUID` type and `FUUID`.
+
+```scala mdoc:silent
+import memeid4s.UUID
+import io.chrisdavenport.fuuid.FUUID
+import memeid4s.fuuid.syntax._
+
+val fuuid: FUUID = UUID.V4.random.toFUUID
+
+val uuid: UUID = fuuid.toUUID
+```
+
+```scala mdoc:reset:silent
+import memeid4s.UUID
+import io.chrisdavenport.fuuid.FUUID
+import memeid4s.fuuid.auto._
+
+def usingFUUID(fuuid: FUUID) = fuuid
+def usingUUID(uuid: UUID) = uuid
+
+val uuid: UUID = UUID.V4.random
+val fuuid: FUUID = FUUID.fromUUID(java.util.UUID.randomUUID)
+
+usingFUUID(uuid)
+usingUUID(fuuid)
+```

--- a/microsite/src/main/resources/microsite/data/menu.yml
+++ b/microsite/src/main/resources/microsite/data/menu.yml
@@ -13,6 +13,8 @@ options:
         url: docs/memeid4s_http4s/
       - title: Tapir
         url: docs/memeid4s_tapir/
+      - title: FUUID
+        url: docs/memeid4s_fuuid/
       - title: Cats & Cats-effect
         url: docs/memeid4s_cats/
       - title: Scalacheck

--- a/modules/memeid4s-fuuid/src/main/scala/memeid4s/fuuid/auto.scala
+++ b/modules/memeid4s-fuuid/src/main/scala/memeid4s/fuuid/auto.scala
@@ -1,0 +1,19 @@
+package memeid4s.fuuid
+
+import io.chrisdavenport.fuuid.FUUID
+import memeid4s.UUID
+
+@SuppressWarnings(Array("scalafix:DisableSyntax.implicitConversion"))
+object auto {
+
+  /**
+   * Provides an automatic conversion between a `FUUID` and a memeid's `UUID`.
+   */
+  implicit def FUUID2UUIDOps(fuuid: FUUID): UUID = UUID.fromUUID(FUUID.Unsafe.toUUID(fuuid))
+
+  /**
+   * Provides an automatic conversion between a memeid's `UUID` and a `FUUID`.
+   */
+  implicit def UUID2FUUIDOps(uuid: UUID): FUUID = FUUID.fromUUID(uuid.asJava())
+
+}

--- a/modules/memeid4s-fuuid/src/main/scala/memeid4s/fuuid/syntax.scala
+++ b/modules/memeid4s-fuuid/src/main/scala/memeid4s/fuuid/syntax.scala
@@ -1,0 +1,26 @@
+package memeid4s.fuuid
+
+import io.chrisdavenport.fuuid.FUUID
+import memeid4s.UUID
+
+object syntax {
+
+  implicit class FUUID2UUIDOps(private val fuuid: FUUID) extends AnyVal {
+
+    /**
+     * Converts the current `FUUID` value to a memeid's `UUID`.
+     */
+    def toUUID: UUID = UUID.fromUUID(FUUID.Unsafe.toUUID(fuuid))
+
+  }
+
+  implicit class UUID2FUUIDOps(private val uuid: UUID) extends AnyVal {
+
+    /**
+     * Converts the current memeid's `UUID` value to a `FUUID`.
+     */
+    def toFUUID: FUUID = FUUID.fromUUID(uuid.asJava())
+
+  }
+
+}

--- a/modules/memeid4s-fuuid/src/test/scala/memeid4s/fuuid/AutoSpec.scala
+++ b/modules/memeid4s-fuuid/src/test/scala/memeid4s/fuuid/AutoSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019-2020 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memeid4s.tapir
+
+import io.chrisdavenport.fuuid.FUUID
+import memeid4s.UUID
+import memeid4s.fuuid.auto._
+import memeid4s.scalacheck.arbitrary.instances._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+class AutoSpec extends Specification with ScalaCheck {
+
+  "UUID-FUUID auto conversions" should {
+
+    "convert between UUID & FUUID" in prop { uuid: UUID =>
+      mustBeEqual(FUUID.fromUUID(uuid.asJava()), uuid)
+    }
+
+  }
+
+  def mustBeEqual(uuid: UUID, fuuid: FUUID) = uuid.asJava must be equalTo FUUID.Unsafe.toUUID(fuuid)
+
+}

--- a/modules/memeid4s-fuuid/src/test/scala/memeid4s/fuuid/SyntaxSpec.scala
+++ b/modules/memeid4s-fuuid/src/test/scala/memeid4s/fuuid/SyntaxSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019-2020 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memeid4s.tapir
+
+import io.chrisdavenport.fuuid.FUUID
+import memeid4s.UUID
+import memeid4s.fuuid.syntax._
+import memeid4s.scalacheck.arbitrary.instances._
+import org.specs2.ScalaCheck
+import org.specs2.mutable.Specification
+
+class SynxtaxSpec extends Specification with ScalaCheck {
+
+  "UUID-FUUID conversions" should {
+
+    "convert between UUID & FUUID" in prop { uuid: UUID =>
+      uuid.toFUUID must be equalTo FUUID.fromUUID(uuid.asJava())
+    }
+
+    "convert between FUUID & UUID" in prop { uuid: UUID =>
+      val fuuid = uuid.toFUUID
+
+      fuuid.toUUID must be equalTo uuid
+    }
+
+  }
+
+}

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -109,7 +109,8 @@ object dependencies extends AutoPlugin {
     "org.tpolecat"                %% "doobie-h2"   % "0.9.2",
     "org.http4s"                  %% "http4s-dsl"  % "0.21.7",
     "org.scalacheck"              %% "scalacheck"  % "1.14.3",
-    "com.softwaremill.sttp.tapir" %% "tapir-core"  % "0.16.16"
+    "com.softwaremill.sttp.tapir" %% "tapir-core"  % "0.16.16",
+    "io.chrisdavenport"           %% "fuuid"       % "0.4.0"
   )
 
   override def trigger: PluginTrigger = allRequirements

--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -31,6 +31,11 @@ object dependencies extends AutoPlugin {
 
     val tapir = "[0.16.0,)"
 
+    val fuuid = on {
+      case (2, 12) => "[0.1.0,)"
+      case (2, 13) => "[0.3.0,)"
+    }
+
   }
   // scala-steward:on
 
@@ -88,6 +93,12 @@ object dependencies extends AutoPlugin {
     )
   }
 
+  private val fuuid = Def.setting {
+    Seq(
+      "io.chrisdavenport" %% "fuuid" % V.fuuid.value % Provided
+    )
+  }
+
   private val scalacheck = Seq(
     "org.scalacheck" %% "scalacheck" % V.scalacheck % Provided
   )
@@ -118,6 +129,7 @@ object dependencies extends AutoPlugin {
           case "memeid4s-circe"      => circe.value
           case "memeid4s-http4s"     => http4s.value
           case "memeid4s-tapir"      => tapir.value
+          case "memeid4s-fuuid"      => fuuid.value
           case "memeid4s-scalacheck" => scalacheck
           case _                     => Nil
         }

--- a/project/descriptions.scala
+++ b/project/descriptions.scala
@@ -19,6 +19,7 @@ object descriptions extends AutoPlugin {
     "memeid4s-circe"      -> "Circe type-classes instances to enable decoding/encoding memeid's UUID values in JSON",
     "memeid4s-http4s"     -> "Http4s type-classes instances to enable using memeid's UUID as a query param in http4s services",
     "memeid4s-tapir"      -> "Tapir type-classes instances to enable using memeid's UUID as path/query param or headers in tapir's endpoints as well as richer documentation",
+    "memeid4s-fuuid"      -> "Conversions between FUUID's UUID class and memeid one",
     "memeid4s-scalacheck" -> "Arbitrary instances for memeid's UUID as well as the different UUID versions"
   )
 


### PR DESCRIPTION
The [FUUID](https://christopherdavenport.github.io/fuuid/) integration provides both semi (via extension methods) and auto conversions between memeid's `UUID` type and `FUUID`.

```scala mdoc:silent
import memeid4s.UUID
import io.chrisdavenport.fuuid.FUUID
import memeid4s.fuuid.syntax._

val fuuid: FUUID = UUID.V4.random.toFUUID

val uuid: UUID = fuuid.toUUID
```

```scala mdoc:reset:silent
import memeid4s.UUID
import io.chrisdavenport.fuuid.FUUID
import memeid4s.fuuid.auto._

def usingFUUID(fuuid: FUUID) = fuuid
def usingUUID(uuid: UUID) = uuid

val uuid: UUID = UUID.V4.random
val fuuid: FUUID = FUUID.fromUUID(java.util.UUID.randomUUID)

usingFUUID(uuid)
usingUUID(fuuid)
```