### PR TITLE
Update tapir-core to 0.17.19

### DIFF
--- a/project/dependencies.scala
+++ b/project/dependencies.scala
@@ -29,8 +29,6 @@ object dependencies extends AutoPlugin {
 
     val scalacheck = "[1.14.0,)"
 
-    val tapir = "[0.16.0,)"
-
     val fuuid = on {
       case (2, 12) => "[0.1.0,)"
       case (2, 13) => "[0.3.0,)"
@@ -87,7 +85,7 @@ object dependencies extends AutoPlugin {
 
   private val tapir = Def.setting {
     Seq(
-      "com.softwaremill.sttp.tapir" %% "tapir-core"               % V.tapir   % Provided,
+      "com.softwaremill.sttp.tapir" %% "tapir-core"               % "0.17.19" % Provided,
       "com.softwaremill.sttp.tapir" %% "tapir-openapi-docs"       % "0.17.19" % Test,
       "com.softwaremill.sttp.tapir" %% "tapir-openapi-circe-yaml" % "0.17.19" % Test
     )


### PR DESCRIPTION
Currently all update PRs from the 47erbot are failing with compile errors (copied below) that are coming from breaking changes in the prerelease versions of tapir. In order to avoid pulling that in, I am setting tapir-core to "0.17.19" and putting it under the `scala-steward:on` section.

```
[error] /home/runner/work/memeid/memeid/modules/memeid4s-tapir/src/main/scala/memeid4s/tapir/instances.scala:19:8: value modifySchema is not a member of sttp.tapir.Codec[String,memeid4s.UUID,sttp.tapir.CodecFormat.TextPlain]
[error] possible cause: maybe a semicolon is missing before `value modifySchema`?
[error]       .modifySchema(_.format("uuid"))
[error]        ^
[error] /home/runner/work/memeid/memeid/modules/memeid4s-tapir/src/main/scala/memeid4s/tapir/instances.scala:24:50: type mismatch;
[error]  found   : sttp.tapir.SchemaType.SString.type
[error]  required: sttp.tapir.SchemaType[?]
[error]   implicit val UUIDSchema: Schema[UUID] = Schema(SString).format("uuid")
[error]                                                  ^
[error] two errors found
```