### PR TITLE
Bump up `sbt-microsites`, `sbt-ci-release` and `sbt-hood-plugin`

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 addSbtPlugin("ch.epfl.scala"                     % "sbt-scalafix"             % "0.10.4")
-addSbtPlugin("com.47deg"                         % "sbt-microsites"           % "1.3.2")
+addSbtPlugin("com.47deg"                         % "sbt-microsites"           % "1.4.1")
 addSbtPlugin("com.alejandrohdezma"               % "sbt-codecov"              % "0.2.1")
 addSbtPlugin("com.alejandrohdezma"               % "sbt-fix"                  % "0.7.0")
 addSbtPlugin("com.alejandrohdezma"               % "sbt-github-header"        % "0.11.6")
@@ -12,7 +12,7 @@ addSbtPlugin("com.alejandrohdezma"               % "sbt-modules"              % 
 addSbtPlugin("com.alejandrohdezma"               % "sbt-remove-test-from-pom" % "0.1.0")
 addSbtPlugin("com.alejandrohdezma"               % "sbt-scalafix-defaults"    % "0.10.0")
 addSbtPlugin("com.alejandrohdezma"               % "sbt-scalafmt-defaults"    % "0.8.0")
-addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"           % "1.5.10")
+addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"           % "1.5.11")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"         % "3.0.2")
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"               % "5.9.0")
 addSbtPlugin("io.github.davidgregory084"         % "sbt-tpolecat"             % "0.4.1")
@@ -20,4 +20,4 @@ addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                 % 
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"             % "2.5.0")
 addSbtPlugin("org.scoverage"                     % "sbt-scoverage"            % "2.0.6")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                  % "0.4.3")
-addSbtPlugin("com.47deg"                        %% "sbt-hood-plugin"          % "0.3.0")
+addSbtPlugin("com.47deg"                        %% "sbt-hood-plugin"          % "0.4.0")


### PR DESCRIPTION
The [update](https://github.com/47degrees/memeid/pull/607) of `sbt-ci-release` had a breaking change. `sbt-microsites` depends on that library too, so we needed to upgrade both. 
Once this was done, I had an evicted problem with some dependencies that `sbt-hood-plugin` brings to `memeid`, so its version is upgraded as well.