### PR TITLE
Add new UUID formats from https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04

### DIFF
--- a/modules/memeid/src/main/java/memeid/Mask.java
+++ b/modules/memeid/src/main/java/memeid/Mask.java
@@ -25,11 +25,13 @@ public final class Mask {
 	public final static long TIME_LOW = 0xFFFFFFFFL;
 	public final static long TIME_MID = 0xFFFF00000000L;
 	public final static long TIME_HIGH = 0xFFF000000000000L;
+    public final static long TIMESTAMP = 0xFFFFFFFFFFFF0000L;
 
 	public final static long CLOCK_SEQ_LOW = 0xFFL;
 	public final static long CLOCK_SEQ_HIGH = 0x3F00L;
 
-	public final static long UB32 = 0xFFFFFFFFL;
+	public final static long UB12 = 0xFFFL;
+    public final static long UB32 = 0xFFFFFFFFL;
 
 	public final static long HASHED = 0xC000000000000000L;
 

--- a/modules/memeid/src/main/java/memeid/Mask.java
+++ b/modules/memeid/src/main/java/memeid/Mask.java
@@ -25,13 +25,13 @@ public final class Mask {
 	public final static long TIME_LOW = 0xFFFFFFFFL;
 	public final static long TIME_MID = 0xFFFF00000000L;
 	public final static long TIME_HIGH = 0xFFF000000000000L;
-    public final static long TIMESTAMP = 0xFFFFFFFFFFFF0000L;
+        public final static long TIMESTAMP = 0xFFFFFFFFFFFF0000L;
 
 	public final static long CLOCK_SEQ_LOW = 0xFFL;
 	public final static long CLOCK_SEQ_HIGH = 0x3F00L;
 
 	public final static long UB12 = 0xFFFL;
-    public final static long UB32 = 0xFFFFFFFFL;
+        public final static long UB32 = 0xFFFFFFFFL;
 
 	public final static long HASHED = 0xC000000000000000L;
 

--- a/modules/memeid/src/main/java/memeid/UUID.java
+++ b/modules/memeid/src/main/java/memeid/UUID.java
@@ -800,45 +800,7 @@ public class UUID implements Comparable<UUID> {
 	 */
 	public final static class V6 extends UUID {
 
-		// /**
-		//  * Get the time_low component of the timestamp field
-		//  *
-		//  * @return time_low component of the timestamp field
-		//  * @see <a href="https://tools.ietf.org/html/rfc4122#section-4.1.2">RFC-4122</a>
-		//  */
-		// public final long timeHigh() {
-		// 	return Bits.readByte(Mask.TIME_LOW, Offset.TIME_LOW, this.asJava().timestamp());
-		// }
-
-		// /**
-		//  * Get the time_mid component of the timestamp field
-		//  *
-		//  * @return time_mid component of the timestamp field
-		//  * @see <a href="https://tools.ietf.org/html/rfc4122#section-4.1.2">RFC-4122</a>
-		//  */
-		// public final long timeLow() {
-		// 	return Bits.readByte(Mask.TIME_MID, Offset.TIME_MID, this.asJava().timestamp());
-		// }
-
-		// /**
-		//  * Get the clock_seq_low component of the clock sequence field
-		//  *
-		//  * @return clock_seq_low component of the clock sequence field
-		//  * @see <a href="https://tools.ietf.org/html/rfc4122#section-4.1.2">RFC-4122</a>
-		//  */
-		// public final long clockSeqLow() {
-		// 	return Bits.readByte(Mask.CLOCK_SEQ_LOW, Offset.CLOCK_SEQ_LOW, this.asJava().clockSequence());
-		// }
-
-		// /**
-		//  * Get the clock_seq_high component of the clock sequence field
-		//  *
-		//  * @return clock_seq_high component of the clock sequence field
-		//  * @see <a href="https://tools.ietf.org/html/rfc4122#section-4.1.2">RFC-4122</a>
-		//  */
-		// public final long clockSeqHigh() {
-		// 	return Bits.readByte(Mask.CLOCK_SEQ_HIGH, Offset.CLOCK_SEQ_HIGH, this.asJava().clockSequence());
-		// }
+                static final long version = 0x6000L;
 
 		private V6(java.util.UUID uuid) {
 			super(uuid);
@@ -875,8 +837,6 @@ public class UUID implements Comparable<UUID> {
 		 * @return a {@link V6} UUID
 		 */
 		public static UUID next(Node node, LongSupplier monotonicSupplier) {
-                    // mostly this is V1 with changes to the order of the time bits by writing 
-                        final long version   = 0x6000L; // cheat to avoid bitshifting
 			final long timestamp = monotonicSupplier.getAsLong();
                         final long ts12      = timestamp & Mask.UB12;
                         final long msb       = timestamp << 16 | version | ts12;

--- a/modules/memeid/src/test/scala/memeid/UUIDSpec.scala
+++ b/modules/memeid/src/test/scala/memeid/UUIDSpec.scala
@@ -56,7 +56,9 @@ class UUIDSpec extends Specification with ScalaCheck {
         case _: UUID.V3             => uuid.version must be equalTo 3
         case _: UUID.V4             => uuid.version must be equalTo 4
         case _: UUID.V5             => uuid.version must be equalTo 5
-        case _: UUID.UnknownVersion => uuid.version must not be between(1, 5)
+        case _: UUID.V6             => uuid.version must be equalTo 6
+        case _: UUID.V7             => uuid.version must be equalTo 7
+        case _: UUID.UnknownVersion => uuid.version must not be between(1, 7)
       }
     }
 
@@ -71,7 +73,9 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
         (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
         (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5]) and
+        (uuid.asV6 must be equalTo Optional.empty[UUID.V6]) and
+        (uuid.asV7 must be equalTo Optional.empty[UUID.V7])
     }
 
     "uuid.asV2 should return optional with uuid only if class is UUID.V2" in prop { (uuid: UUID.V2) =>
@@ -79,7 +83,9 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.asV2 must be equalTo Optional.of[UUID.V2](uuid)) and
         (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
         (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5]) and
+        (uuid.asV6 must be equalTo Optional.empty[UUID.V6]) and
+        (uuid.asV7 must be equalTo Optional.empty[UUID.V7])
     }
 
     "uuid.asV3 should return optional with uuid only if class is UUID.V3" >> {
@@ -89,7 +95,9 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
         (uuid.asV3 must be equalTo Optional.of[UUID.V3](uuid)) and
         (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5]) and
+        (uuid.asV6 must be equalTo Optional.empty[UUID.V6]) and
+        (uuid.asV7 must be equalTo Optional.empty[UUID.V7])
     }
 
     "uuid.asV4 should return optional with uuid only if class is UUID.V4" >> {
@@ -99,7 +107,9 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
         (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
         (uuid.asV4 must be equalTo Optional.of[UUID.V4](uuid)) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V5])
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5]) and
+        (uuid.asV6 must be equalTo Optional.empty[UUID.V6]) and
+        (uuid.asV7 must be equalTo Optional.empty[UUID.V7])
     }
 
     "uuid.asV5 should return optional with uuid only if class is UUID.V5" >> {
@@ -109,7 +119,33 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
         (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
         (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
-        (uuid.asV5 must be equalTo Optional.of[UUID.V5](uuid))
+        (uuid.asV5 must be equalTo Optional.of[UUID.V5](uuid)) and
+        (uuid.asV6 must be equalTo Optional.empty[UUID.V6]) and
+        (uuid.asV7 must be equalTo Optional.empty[UUID.V7])
+    }
+
+    "uuid.asV6 should return optional with uuid only if class is UUID.V6" >> {
+      val uuid = UUID.V6.next().asInstanceOf[UUID.V6]
+
+      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5]) and
+        (uuid.asV6 must be equalTo Optional.of[UUID.V6](uuid)) and
+        (uuid.asV7 must be equalTo Optional.empty[UUID.V7])
+    }
+
+    "uuid.asV5 should return optional with uuid only if class is UUID.V5" >> {
+      val uuid = UUID.V7.next().asInstanceOf[UUID.V7]
+
+      (uuid.asV1 must be equalTo Optional.empty[UUID.V1]) and
+        (uuid.asV2 must be equalTo Optional.empty[UUID.V2]) and
+        (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
+        (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
+        (uuid.asV5 must be equalTo Optional.empty[UUID.V5]) and
+        (uuid.asV6 must be equalTo Optional.empty[UUID.V6]) and
+        (uuid.asV7 must be equalTo Optional.of[UUID.V7](uuid))
     }
 
   }

--- a/modules/memeid/src/test/scala/memeid/V6Spec.scala
+++ b/modules/memeid/src/test/scala/memeid/V6Spec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019-2023 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memeid
+
+import scala.collection.parallel.immutable.ParRange
+
+import org.specs2.mutable.Specification
+
+@SuppressWarnings(Array("scalafix:Disable.scala.collection.parallel"))
+class V6Spec extends Specification {
+
+  "V6 constructor" should {
+
+    "create version 6 UUIDs" in {
+      val ids = new ParRange(1 to 10).map(_ => UUID.V6.next.version).toVector.toSet
+
+      ids must contain(exactly(6))
+    }
+
+    "create monotonically increasing UUIDs" in {
+      val uuid1: UUID = UUID.V6.next
+      val uuid2: UUID = UUID.V6.next
+
+      uuid1 must be lessThan uuid2
+    }
+
+    "not generate the same UUID twice" in {
+      val ids = new ParRange(1 to 10).map(_ => UUID.V6.next).toSet
+
+      ids.size must be equalTo 10
+    }
+
+    "not generate the same UUID twice with high concurrency" in {
+      val ids = new ParRange(1 to 999).map(_ => UUID.V6.next).toSet
+
+      ids.size must be equalTo 999
+    }
+
+  }
+
+}

--- a/modules/memeid/src/test/scala/memeid/V7Spec.scala
+++ b/modules/memeid/src/test/scala/memeid/V7Spec.scala
@@ -43,7 +43,7 @@ class V7Spec extends Specification {
     }
 
     "generate a version 7 UUID with the proper timestamp" in {
-      val uuid: UUID.V7 = UUID.V7.next(-1).asV7().get();
+      val uuid: UUID.V7 = UUID.V7.next(-1).asV7().get()
       uuid.timestamp must be equalTo 281474976710655L
     }
   }

--- a/modules/memeid/src/test/scala/memeid/V7Spec.scala
+++ b/modules/memeid/src/test/scala/memeid/V7Spec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019-2023 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memeid
+
+import scala.collection.parallel.immutable.ParRange
+
+import org.specs2.mutable.Specification
+
+@SuppressWarnings(Array("scalafix:Disable.scala.collection.parallel"))
+class V7Spec extends Specification {
+
+  "V7 constructor" should {
+
+    "create version 7 UUIDs" in {
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V7.next.version).toVector.toSet
+
+      uuids must contain(exactly(7))
+    }
+
+    "not generate the same UUID twice" in {
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V7.next).toVector.toSet
+
+      uuids.size must be equalTo 10
+    }
+
+    "generate version 7 UUIDs regardless of timestamp value provided" in {
+      val nonNull: UUID = UUID.V7.next(0)
+      nonNull.version must be equalTo 7
+    }
+
+    "generate a version 7 UUID with the proper timestamp" in {
+      val uuid: UUID.V7 = UUID.V7.next(-1).asV7().get();
+      uuid.timestamp must be equalTo 281474976710655L
+    }
+  }
+
+}

--- a/modules/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
+++ b/modules/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
@@ -83,6 +83,15 @@ object instances {
     } yield UUID.V5.from(namespace, name).asInstanceOf[UUID.V5]
   }
 
+  implicit val UUIDV6ArbitraryInstance: Arbitrary[UUID.V6] = Arbitrary {
+    for {
+      timestamp     <- arbitrary[Long]
+      clockSequence <- arbitrary[Short]
+      id            <- arbitrary[Long]
+      node           = new Node(clockSequence, id)
+    } yield UUID.V6.next(node, () => timestamp).asInstanceOf[UUID.V6]
+  }
+
   implicit val UUIDV7ArbitraryInstance: Arbitrary[UUID.V7] = Arbitrary {
     for {
       timestamp <- arbitrary[Long]

--- a/modules/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
+++ b/modules/memeid4s-scalacheck/src/main/scala/memeid4s/scalacheck/arbitrary/instances.scala
@@ -83,4 +83,10 @@ object instances {
     } yield UUID.V5.from(namespace, name).asInstanceOf[UUID.V5]
   }
 
+  implicit val UUIDV7ArbitraryInstance: Arbitrary[UUID.V7] = Arbitrary {
+    for {
+      timestamp <- arbitrary[Long]
+    } yield UUID.V7.next(timestamp).asInstanceOf[UUID.V7]
+  }
+
 }

--- a/modules/memeid4s/src/main/scala/memeid4s/UUID.scala
+++ b/modules/memeid4s/src/main/scala/memeid4s/UUID.scala
@@ -1,4 +1,4 @@
-/*
+/**
  * Copyright 2019-2023 47 Degrees Open Source <https://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,6 +39,8 @@ object UUID {
   type V4 = memeid.UUID.V4
 
   type V5 = memeid.UUID.V5
+
+  type V6 = memeid.UUID.V6
 
   type V7 = memeid.UUID.V7
 
@@ -196,6 +198,20 @@ object UUID {
     @inline def apply[A](namespace: UUID, local: A)(implicit D: Digestible[A]): UUID =
       memeid.UUID.V5.from(namespace, local, D.toByteArray)
 
+  }
+
+  object V6 {
+    /** Construct a [[UUID.V6 V6]] (time-based) UUID.
+      *
+      * @param N
+      *   [[node.Node Node]] for the V6 UUID generation
+      * @param T
+      *   [[time.Time Time]] which assures the V6 UUID time is unique
+      * @return
+      *   [[UUID.V6 V6]]
+      */
+    @inline def next(implicit N: Node, T: Time): UUID =
+      memeid.UUID.V6.next(N.value, () => T.monotonic)
   }
 
   object V7 {

--- a/modules/memeid4s/src/main/scala/memeid4s/UUID.scala
+++ b/modules/memeid4s/src/main/scala/memeid4s/UUID.scala
@@ -1,18 +1,14 @@
-/**
- * Copyright 2019-2023 47 Degrees Open Source <https://www.47deg.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/** Copyright 2019-2023 47 Degrees Open Source <https://www.47deg.com>
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+  * the License. You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  * specific language governing permissions and limitations under the License.
+  */
 
 package memeid4s
 
@@ -201,6 +197,7 @@ object UUID {
   }
 
   object V6 {
+
     /** Construct a [[UUID.V6 V6]] (time-based) UUID.
       *
       * @param N
@@ -212,13 +209,13 @@ object UUID {
       */
     @inline def next(implicit N: Node, T: Time): UUID =
       memeid.UUID.V6.next(N.value, () => T.monotonic)
+
   }
 
   object V7 {
 
-    /** Construct a timestamp plus random v7 UUID. There's 48 bits of unix
-      * millisecond timestamp and the rest is random bits. This uses
-      * [[System.currentTimeMillis]] to get the current time.
+    /** Construct a timestamp plus random v7 UUID. There's 48 bits of unix millisecond timestamp and the rest is random
+      * bits. This uses [[System.currentTimeMillis]] to get the current time.
       *
       * @return
       *   [[UUID.V7 V7]]

--- a/modules/memeid4s/src/main/scala/memeid4s/UUID.scala
+++ b/modules/memeid4s/src/main/scala/memeid4s/UUID.scala
@@ -40,6 +40,8 @@ object UUID {
 
   type V5 = memeid.UUID.V5
 
+  type V7 = memeid.UUID.V7
+
   @SuppressWarnings(Array("scalafix:DisableSyntax.implicitConversion"))
   implicit def richUUID(uuid: memeid.UUID): RichUUID = new RichUUID(uuid)
 
@@ -193,6 +195,20 @@ object UUID {
       */
     @inline def apply[A](namespace: UUID, local: A)(implicit D: Digestible[A]): UUID =
       memeid.UUID.V5.from(namespace, local, D.toByteArray)
+
+  }
+
+  object V7 {
+
+    /** Construct a timestamp plus random v7 UUID. There's 48 bits of unix
+      * millisecond timestamp and the rest is random bits. This uses
+      * [[System.currentTimeMillis]] to get the current time.
+      *
+      * @return
+      *   [[UUID.V7 V7]]
+      */
+    @inline def apply(): UUID =
+      memeid.UUID.V7.next()
 
   }
 

--- a/modules/memeid4s/src/test/scala/memeid4s/UUIDSpec.scala
+++ b/modules/memeid4s/src/test/scala/memeid4s/UUIDSpec.scala
@@ -119,7 +119,7 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
         (uuid.asV5 must be equalTo Optional.of[UUID.V5](uuid)) and
         (uuid.asV6 must be equalTo Optional.empty[UUID.V6]) and
-        (uuid.asV7 must be equalTo Optional.empty[UUID.V7]) 
+        (uuid.asV7 must be equalTo Optional.empty[UUID.V7])
     }
 
   }

--- a/modules/memeid4s/src/test/scala/memeid4s/UUIDSpec.scala
+++ b/modules/memeid4s/src/test/scala/memeid4s/UUIDSpec.scala
@@ -92,7 +92,8 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.is[UUID.V2] must beFalse) and
         (uuid.is[UUID.V3] must beFalse) and
         (uuid.is[UUID.V4] must beFalse) and
-        (uuid.is[UUID.V5] must beFalse)
+        (uuid.is[UUID.V5] must beFalse) and
+        (uuid.is[UUID.V7] must beFalse)
     }
 
     "return true only if version is 2" in prop { (uuid: UUID.V2) =>
@@ -100,7 +101,8 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.is[UUID.V2] must beTrue) and
         (uuid.is[UUID.V3] must beFalse) and
         (uuid.is[UUID.V4] must beFalse) and
-        (uuid.is[UUID.V5] must beFalse)
+        (uuid.is[UUID.V5] must beFalse) and
+        (uuid.is[UUID.V7] must beFalse)
     }
 
     "return true only if version is 3" in prop { (uuid: UUID.V3) =>
@@ -108,7 +110,8 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.is[UUID.V2] must beFalse) and
         (uuid.is[UUID.V3] must beTrue) and
         (uuid.is[UUID.V4] must beFalse) and
-        (uuid.is[UUID.V5] must beFalse)
+        (uuid.is[UUID.V5] must beFalse) and
+        (uuid.is[UUID.V7] must beFalse)
     }
 
     "return true only if version is 4" in prop { (uuid: UUID.V4) =>
@@ -116,7 +119,8 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.is[UUID.V2] must beFalse) and
         (uuid.is[UUID.V3] must beFalse) and
         (uuid.is[UUID.V4] must beTrue) and
-        (uuid.is[UUID.V5] must beFalse)
+        (uuid.is[UUID.V5] must beFalse) and
+        (uuid.is[UUID.V7] must beFalse)
     }
 
     "return true only if version is 5" in prop { (uuid: UUID.V5) =>
@@ -124,7 +128,18 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.is[UUID.V2] must beFalse) and
         (uuid.is[UUID.V3] must beFalse) and
         (uuid.is[UUID.V4] must beFalse) and
-        (uuid.is[UUID.V5] must beTrue)
+        (uuid.is[UUID.V5] must beTrue) and
+        (uuid.is[UUID.V7] must beFalse)
+
+    }
+
+    "return true only if version is 7" in prop { (uuid: UUID.V7) =>
+      (uuid.is[UUID.V1] must beFalse) and
+        (uuid.is[UUID.V2] must beFalse) and
+        (uuid.is[UUID.V3] must beFalse) and
+        (uuid.is[UUID.V4] must beFalse) and
+        (uuid.is[UUID.V5] must beFalse) and
+        (uuid.is[UUID.V7] must beTrue)
     }
 
   }

--- a/modules/memeid4s/src/test/scala/memeid4s/UUIDSpec.scala
+++ b/modules/memeid4s/src/test/scala/memeid4s/UUIDSpec.scala
@@ -74,8 +74,8 @@ class UUIDSpec extends Specification with ScalaCheck {
         (uuid.asV3 must be equalTo Optional.empty[UUID.V3]) and
         (uuid.asV4 must be equalTo Optional.empty[UUID.V4]) and
         (uuid.asV5 must be equalTo Optional.empty[UUID.V5]) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V6]) and
-        (uuid.asV5 must be equalTo Optional.empty[UUID.V7])
+        (uuid.asV6 must be equalTo Optional.empty[UUID.V6]) and
+        (uuid.asV7 must be equalTo Optional.empty[UUID.V7])
     }
 
     "uuid.asV2 should return optional with uuid only if class is UUID.V2" in prop { (uuid: UUID.V2) =>

--- a/modules/memeid4s/src/test/scala/memeid4s/V6Spec.scala
+++ b/modules/memeid4s/src/test/scala/memeid4s/V6Spec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019-2023 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memeid4s
+
+import scala.collection.parallel.immutable.ParRange
+
+import org.specs2.mutable.Specification
+
+@SuppressWarnings(Array("scalafix:Disable.scala.collection.parallel"))
+class V6Spec extends Specification {
+
+  "V6 constructor" should {
+
+    "create version 1 UUIDs" in {
+      val ids = new ParRange(1 to 10).map(_ => UUID.V6.next.version).toVector.toSet
+
+      ids must contain(exactly(6))
+    }
+
+    "create monotonically increasing UUIDs" in {
+      val uuid1: UUID = UUID.V6.next
+      val uuid2: UUID = UUID.V6.next
+
+      uuid1 must be lessThan uuid2
+    }
+
+    "not generate the same UUID twice" in {
+      val ids = new ParRange(1 to 10).map(_ => UUID.V6.next).toSet
+
+      ids.size must be equalTo 10
+    }
+
+    "not generate the same UUID twice with high concurrency" in {
+      val ids = new ParRange(1 to 999).map(_ => UUID.V6.next).toSet
+
+      ids.size must be equalTo 999
+    }
+
+    // "check time components" in {
+    //   val uuid         = memeid.UUID.fromString("1cbf0782-3209-11ea-978f-2e728ce88125")
+    //   val clockSeqLow  = 0x8f.toLong
+    //   val clockSeqHigh = 0x17.toLong // 0x97 - 0x80 (from variant)
+    //   val timeLow      = 0x1cbf0782.toLong
+    //   val timeMid      = 0x3209.toLong
+    //   val timeHigh     = 0x1ea.toLong
+    //   val uuidV6       = uuid.asV6.get
+
+    //   uuidV6.clockSeqLow must be equalTo clockSeqLow
+    //   uuidV6.clockSeqHigh must be equalTo clockSeqHigh
+    //   uuidV6.timeLow must be equalTo timeLow
+    //   uuidV6.timeMid must be equalTo timeMid
+    //   uuidV6.timeHigh must be equalTo timeHigh
+    // }
+  }
+
+}

--- a/modules/memeid4s/src/test/scala/memeid4s/V7Spec.scala
+++ b/modules/memeid4s/src/test/scala/memeid4s/V7Spec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019-2023 47 Degrees Open Source <https://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memeid4s
+
+import scala.collection.parallel.immutable.ParRange
+
+import org.specs2.mutable.Specification
+
+@SuppressWarnings(Array("scalafix:Disable.scala.collection.parallel"))
+class V7Spec extends Specification {
+
+  "V7 constructor" should {
+
+    "create version 7 UUIDs" in {
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V7().version).toVector.toSet
+
+      uuids must contain(exactly(7))
+    }
+
+    "not generate the same UUID twice" in {
+      val uuids = new ParRange(1 to 10).map(_ => UUID.V7()).toVector.toSet
+
+      uuids.size must be equalTo 10
+    }
+
+    "be unable to create non-v7 values regardless of msb/lsb values provided" in {
+      val nonNull: UUID = UUID.V7()
+      nonNull must not be equalTo(UUID.Nil)
+    }
+
+    "generate version 7 UUIDs regardless of msb/lsb values provided" in {
+      val nonNull: UUID = UUID.V7()
+      nonNull.version must be equalTo 7
+    }
+
+  }
+
+}


### PR DESCRIPTION
The new versions of UUIDs (version 6,7, and 8) are defined in  https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04 This PR currently only supports version 7 as it's currently at most immediate need to me. 